### PR TITLE
feat(monitoring): set env variable USER_AGENT

### DIFF
--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -28,6 +28,8 @@ export function runGGShieldCommand(
     env: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       GITGUARDIAN_API_URL: apiUrl,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      USER_AGENT: "gitguardian-vscode",
     },
     encoding: "utf-8",
     windowsHide: true,


### PR DESCRIPTION
Set env variable to USER_AGENT=vscode in ggshield calls to track the number of calls coming from the extension. 

Related to: https://github.com/GitGuardian/ggshield/pull/961