### PR TITLE
feat(ignore_fp): Add option to ignore one secret

### DIFF
--- a/src/gitguardian-hover-provider.ts
+++ b/src/gitguardian-hover-provider.ts
@@ -1,0 +1,71 @@
+import * as vscode from "vscode";
+
+export class GitGuardianSecretHoverProvider implements vscode.HoverProvider {
+  public provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.Hover> {
+    const diagnostics = vscode.languages.getDiagnostics(document.uri);
+
+    for (const diagnostic of diagnostics) {
+      if (
+        diagnostic.range.contains(position) &&
+        diagnostic.source === "gitguardian"
+      ) {
+        const hoverMessage = new vscode.MarkdownString();
+        hoverMessage.isTrusted = true;
+
+        const diagnosticData = diagnosticToJSON(diagnostic);
+        const encodedDiagnosticData = encodeURIComponent(diagnosticData);
+
+        hoverMessage.appendMarkdown(
+          `[GitGuardian: Ignore Secret](command:gitguardian.ignoreSecret?${encodedDiagnosticData} "Click to ignore this incident")`
+        );
+        return new vscode.Hover(hoverMessage, diagnostic.range);
+      }
+    }
+
+    return null;
+  }
+}
+
+function diagnosticToJSON(diagnostic: vscode.Diagnostic) {
+  // Extract the infos useful to generate the secret name
+  const { detector, secretSha } = extractInfosFromMessage(diagnostic.message);
+
+  const diagnosticObject = {
+    startLine: diagnostic.range.start.line,
+    detector: detector,
+    secretSha: secretSha,
+  };
+
+  // Convert the object to a JSON string
+  return JSON.stringify(diagnosticObject);
+}
+
+function extractInfosFromMessage(message: string): {
+  detector: string;
+  secretSha: string;
+} {
+  const regexDetectorPattern = /Secret detected: ([a-zA-Z ]+)/;
+  const regexShaPattern = /Secret SHA: ([a-zA-Z0-9]+)/;
+
+  const matchDetector = message.match(regexDetectorPattern);
+  const matchSha = message.match(regexShaPattern);
+
+  if (matchDetector && matchSha) {
+    const detector = matchDetector[1].trim();
+    const secretSha = matchSha[1].trim();
+    return { detector, secretSha };
+  } else {
+    throw new Error("No match found");
+  }
+}
+
+export function generateSecretName(
+  currentFile: string,
+  uriDiagnostic: any
+): string {
+  return `${uriDiagnostic.detector} - ${currentFile}:l.${uriDiagnostic.startLine}`;
+}

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -95,6 +95,32 @@ export function ignoreLastFound(
 }
 
 /**
+ * Ignore one secret.
+ *
+ * Show error message on failure
+ */
+export function ignoreSecret(
+  configuration: GGShieldConfiguration,
+  secretSha: string,
+  secretName: string
+): boolean {
+  const proc = runGGShieldCommand(configuration, [
+    "secret",
+    "ignore",
+    secretSha,
+    "--name",
+    secretName,
+  ]);
+  if (proc.stderr || proc.error) {
+    console.log(proc.stderr);
+    return false;
+  } else {
+    console.log(proc.stdout);
+    return true;
+  }
+}
+
+/**
  * Scan a file using ggshield CLI application
  *
  * Show error messages on failure

--- a/src/lib/ggshield-results-parser.ts
+++ b/src/lib/ggshield-results-parser.ts
@@ -62,6 +62,8 @@ Incident URL: ${incident.incident_url || "N/A"}
 Secret SHA: ${incident.ignore_sha}`,
               DiagnosticSeverity.Warning
             );
+
+            diagnostic.source = "gitguardian";
             diagnostics.push(diagnostic);
           });
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
+import * as vscode from "vscode";
 import { spawnSync } from "child_process";
+import path = require("path");
 
 export async function isGitInstalled(): Promise<boolean> {
   return new Promise((resolve) => {
@@ -10,4 +12,13 @@ export async function isGitInstalled(): Promise<boolean> {
       resolve(true);
     }
   });
+}
+
+export function getCurrentFile(): string {
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor) {
+    return activeEditor.document.fileName;
+  } else {
+    return "";
+  }
 }


### PR DESCRIPTION
Add an option to ignore one secret. The option is accessible if mouse-over an incident (cf. picture)

![image](https://github.com/user-attachments/assets/d5ab9748-ce04-4e34-a680-e59175df916e)

- Clicking the option "Gitguardian: Ignore Secret" adds an entry to the `.gitguardian.yaml` 
- The entry name follows the pattern: `Dector Name - File Name:l.x` (cf. picture)
![image](https://github.com/user-attachments/assets/7ef5606d-1128-45f6-a7fb-f95432287bdb)
 - The option is not displayed in incidents that are not gitguardian-found secrets. 

To validate (since the option is not available yet on ggshield):
- get corresponding branch in ggshield -> `pipenv shell` -> `which ggshield`
- Use this version of ggshield in the settings of the extension
