### PR TITLE
Prevent scanning gitignored files

### DIFF
--- a/src/gitguardian-interface/gitguardian-status-bar.ts
+++ b/src/gitguardian-interface/gitguardian-status-bar.ts
@@ -1,4 +1,8 @@
-import { StatusBarItem, ThemeColor } from "vscode";
+import { ExtensionContext, StatusBarAlignment, StatusBarItem, ThemeColor, window } from "vscode";
+
+
+let statusBarItem: StatusBarItem;
+
 
 export interface StatusBarConfig {
   text: string;
@@ -16,7 +20,13 @@ export enum StatusBarStatus {
   error = "Error",
 }
 
-export function getStatusBarConfig(status: StatusBarStatus): StatusBarConfig {
+export function createStatusBarItem(context: ExtensionContext): void {
+  statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 0);
+  updateStatusBarItem(StatusBarStatus.initialization);
+  context.subscriptions.push(statusBarItem);
+}
+
+function getStatusBarConfig(status: StatusBarStatus): StatusBarConfig {
   switch (status) {
     case StatusBarStatus.initialization:
       return {
@@ -64,7 +74,6 @@ export function getStatusBarConfig(status: StatusBarStatus): StatusBarConfig {
 
 export function updateStatusBarItem(
   status: StatusBarStatus,
-  statusBarItem: StatusBarItem
 ): void {
   const config = getStatusBarConfig(status);
   statusBarItem.text = config.text;

--- a/src/gitguardian-interface/gitguardian-status-bar.ts
+++ b/src/gitguardian-interface/gitguardian-status-bar.ts
@@ -18,6 +18,7 @@ export enum StatusBarStatus {
   secretFound = "Secret found",
   noSecretFound = "No secret found",
   error = "Error",
+  ignoredFile = "Ignored file",
 }
 
 export function createStatusBarItem(context: ExtensionContext): void {
@@ -66,6 +67,11 @@ function getStatusBarConfig(status: StatusBarStatus): StatusBarConfig {
         text: "GitGuardian - error",
         color: "statusBarItem.errorBackground",
         command: "gitguardian.showOutput",
+      };
+    case StatusBarStatus.ignoredFile:
+      return {
+        text: "GitGuardian - Ignored file",
+        color: "statusBarItem.warningBackground",
       };
     default:
       return { text: "", color: "statusBar.foreground" };

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -8,7 +8,7 @@ import axios from 'axios';
 import { GGShieldConfiguration } from "./ggshield-configuration";
 import { GGShieldScanResults } from "./api-types";
 import * as os from "os";
-import { apiToDashboard, dasboardToApi } from "../utils";
+import { apiToDashboard, dasboardToApi, isFileGitignored } from "../utils";
 import { runGGShieldCommand } from "./run-ggshield";
 import { StatusBarStatus, updateStatusBarItem } from "../gitguardian-interface/gitguardian-status-bar";
 import { parseGGShieldResults } from "./ggshield-results-parser";
@@ -16,7 +16,7 @@ import { parseGGShieldResults } from "./ggshield-results-parser";
 /**
  * Extension diagnostic collection
  */
-let diagnosticCollection: DiagnosticCollection;
+export let diagnosticCollection: DiagnosticCollection;
 
 /**
  * Display API quota
@@ -153,6 +153,10 @@ export async function scanFile(
   fileUri: Uri,
   configuration: GGShieldConfiguration
 ): Promise<void> {
+  if (isFileGitignored(filePath)) {
+    updateStatusBarItem(StatusBarStatus.ignoredFile);
+    return;
+  }
   const proc = runGGShieldCommand(configuration, [
     "secret",
     "scan",

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -1,0 +1,41 @@
+export const scanResultsNoIncident =
+  '{"id": "test.py", "type": "path_scan", "total_incidents": 0, "total_occurrences": 0}';
+
+export const scanResultsWithIncident = `{
+    "id":"test.py",
+    "type":"path_scan",
+    "entities_with_incidents":[
+       {
+          "mode":"FILE",
+          "filename":"test.py",
+          "incidents":[
+             {
+                "policy":"Secrets detection",
+                "occurrences":[
+                   {
+                      "match":"DDACC73DdB04********************************************057c78317C39",
+                      "type":"apikey",
+                      "line_start":4,
+                      "line_end":4,
+                      "index_start":11,
+                      "index_end":79,
+                      "pre_line_start":4,
+                      "pre_line_end":4
+                   }
+                ],
+                "type":"Generic High Entropy Secret",
+                "validity":"no_checker",
+                "ignore_sha":"38353eb1a2aac5b24f39ed67912234d4b4a2e23976d504a88b28137ed2b9185e",
+                "total_occurrences":1,
+                "incident_url":"",
+                "known_secret":false
+             }
+          ],
+          "total_incidents":1,
+          "total_occurrences":1
+       }
+    ],
+    "total_incidents":1,
+    "total_occurrences":1,
+    "secrets_engine_version":"2.96.0"
+    }`;

--- a/src/test/suite/lib/ggshield-api.test.ts
+++ b/src/test/suite/lib/ggshield-api.test.ts
@@ -1,0 +1,93 @@
+import { GGShieldConfiguration } from "../../../lib/ggshield-configuration";
+import * as statusBar from "../../../gitguardian-interface/gitguardian-status-bar";
+import * as simple from "simple-mock";
+import { diagnosticCollection, scanFile } from "../../../lib/ggshield-api";
+import * as runGGShield from "../../../lib/run-ggshield";
+import path = require("path");
+import { Uri, window } from "vscode";
+import assert = require("assert");
+import {
+  scanResultsNoIncident,
+  scanResultsWithIncident,
+} from "../../constants";
+
+suite("scanFile", () => {
+  let updateStatusBarMock: simple.Stub<Function>;
+  let runGGShieldCommandMock: simple.Stub<Function>;
+
+  setup(() => {
+    updateStatusBarMock = simple.mock(statusBar, "updateStatusBarItem");
+    runGGShieldCommandMock = simple.mock(runGGShield, "runGGShieldCommand");
+  });
+
+  teardown(() => {
+    simple.restore();
+  });
+
+  test("successfully scans a file with no incidents", async () => {
+    runGGShieldCommandMock.returnWith({
+      status: 0,
+      stdout: scanResultsNoIncident,
+      stderr: "",
+    });
+
+    await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
+
+    // The status bar displays "No Secret Found"
+    assert.strictEqual(updateStatusBarMock.callCount, 1);
+    assert.strictEqual(
+      updateStatusBarMock.lastCall.args[0],
+      statusBar.StatusBarStatus.noSecretFound
+    );
+  });
+
+  test("successfully scans a file with incidents", async () => {
+    runGGShieldCommandMock.returnWith({
+      status: 0,
+      stdout: scanResultsWithIncident,
+      stderr: "",
+    });
+
+    await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
+
+    // The status bar displays "Secret Found"
+    assert.strictEqual(updateStatusBarMock.callCount, 1);
+    assert.strictEqual(
+      updateStatusBarMock.lastCall.args[0],
+      statusBar.StatusBarStatus.secretFound
+    );
+
+    // The diagnostic collection contains the incident
+    assert.strictEqual(
+      diagnosticCollection.get(Uri.file("test.py"))?.length,
+      1
+    );
+  });
+
+  test("skips the file if it is ignored", async () => {
+    const filePath = "out/test.py";
+    await scanFile(filePath, Uri.file(filePath), {} as GGShieldConfiguration);
+
+    // The status bar displays "Ignored File"
+    assert.strictEqual(updateStatusBarMock.callCount, 1);
+    assert.strictEqual(
+      updateStatusBarMock.lastCall.args[0],
+      statusBar.StatusBarStatus.ignoredFile
+    );
+  });
+
+  test("displays an error message if the scan command fails", async () => {
+    const errorMessageMock = simple.mock(window, "showErrorMessage");
+    runGGShieldCommandMock.returnWith({
+      status: 1,
+      stdout: "",
+      stderr: "Error",
+    });
+
+    await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
+
+    // The error message is displayed
+    assert.strictEqual(errorMessageMock.callCount, 1);
+    assert.strictEqual(errorMessageMock.lastCall.args[0], "ggshield: Error\n");
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,12 @@ export async function isGitInstalled(): Promise<boolean> {
   });
 }
 
+// Since git is required to use ggshield, we know that it is installed
+export function isFileGitignored(filePath: string): boolean {
+  let proc = spawnSync("git", ["check-ignore", filePath]);
+  return proc.status === 0;
+}
+
 export function getCurrentFile(): string {
   const activeEditor = vscode.window.activeTextEditor;
   if (activeEditor) {
@@ -28,7 +34,9 @@ export function getCurrentFile(): string {
 }
 
 export function dasboardToApi(dashboardUrl: string): string {
-  const domainMatch = gitGuardianDomains.some((domain) => dashboardUrl.includes(domain));
+  const domainMatch = gitGuardianDomains.some((domain) =>
+    dashboardUrl.includes(domain)
+  );
   if (domainMatch) {
     return dashboardUrl.replace(reDashboard, reApi);
   } else {
@@ -37,7 +45,9 @@ export function dasboardToApi(dashboardUrl: string): string {
 }
 
 export function apiToDashboard(apiUrl: string): string {
-  const domainMatch = gitGuardianDomains.some((domain) => apiUrl.includes(domain));
+  const domainMatch = gitGuardianDomains.some((domain) =>
+    apiUrl.includes(domain)
+  );
   if (domainMatch) {
     return apiUrl.replace(reApi, reDashboard);
   } else {


### PR DESCRIPTION
This MR does a lot of things and is best reviewed commit by commit. Here are the list of commits :
- [chore(status_bar): refactor status bar item](https://github.com/GitGuardian/gitguardian-vscode/pull/41/commits/26ca86d5ad80d3d08b348f98be902d50958a363a) : This puts all logic related to the statusBar into the `gitguardian-status-bar.ts`. This allows functions that need to update the statusBarItem to be in other files than `extension.ts` since they no longer need to pass the statusBarItem as argument to `updateStatusBarItem`
- [chore(scan): separate scan function into separate file](https://github.com/GitGuardian/gitguardian-vscode/pull/41/commits/6d2c8108fdd8b8874afef6e21c1faeec18e88859) : This makes use of the first commit to move `scanFile` to the `ggshield-api.test.ts` and merge it with `ggshieldScanFile`, so that all logic related to scanning is no longer in `extension.ts`, but in its dedicated file.
- [feat(scan): prevent scanning gitignored files](https://github.com/GitGuardian/gitguardian-vscode/pull/41/commits/c792615e2f33f5864ec92b53120bb28cb0f39749) : This adds a test at the beginning of `scanFile` in order to prevent scanning gitignored files, and instead display "Ignored File" in the statusBarItem. This commit also adds tests on `scanFile`