### PR TITLE
fix(configuration): Load .env configuration

### DIFF
--- a/src/lib/run-ggshield.ts
+++ b/src/lib/run-ggshield.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { spawnSync, SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from "child_process";
 import { GGShieldConfiguration } from "./ggshield-configuration";
 import { workspace } from "vscode";
@@ -18,18 +19,15 @@ export function runGGShieldCommand(
     let env: {
       GITGUARDIAN_API_URL: string;
       GG_USER_AGENT: string;
-      GITGUARDIAN_DONT_LOAD_ENV: string;
       GITGUARDIAN_API_KEY?: string;
       } = {
       GITGUARDIAN_API_URL: apiUrl,
       GG_USER_AGENT: "gitguardian-vscode",
-      GITGUARDIAN_DONT_LOAD_ENV: "true",
     };
 
     if (apiKey) {
       env = {
         ...env,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         GITGUARDIAN_API_KEY: apiKey,
       };
     }


### PR DESCRIPTION
To test the interaction with the proxy: 
- Set up a proxy using `mitmproxy`
- Add `https_proxy=http://localhost:8080` to the .env file of the project
- Verify that requests are being logged by the proxy. (you might have to add `--allow-self-signed` to the arguments of the calls ggshield to make it work)