### PR TITLE
fix(env): Extend env with global variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [commit]
+default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -317,7 +317,6 @@ export function ggshieldApiKey(
     console.log(proc.stderr);
     return undefined;
   } else {
-    console.log(proc.stdout);
     const apiUrl = configuration.apiUrl;
 
     const regexInstanceSection = `\\[${apiToDashboard(

--- a/src/lib/run-ggshield.ts
+++ b/src/lib/run-ggshield.ts
@@ -20,20 +20,14 @@ export function runGGShieldCommand(
   args: string[]
 ): SpawnSyncReturns<string> {
   const { ggshieldPath, apiUrl, apiKey } = configuration;
-  let env: {
-    GITGUARDIAN_API_URL: string;
-    GG_USER_AGENT: string;
-    GITGUARDIAN_API_KEY?: string;
-  } = {
+  let env: NodeJS.ProcessEnv = {
+    ...process.env,
     GITGUARDIAN_API_URL: apiUrl,
     GG_USER_AGENT: "gitguardian-vscode",
   };
 
   if (apiKey) {
-    env = {
-      ...env,
-      GITGUARDIAN_API_KEY: apiKey,
-    };
+    env.GITGUARDIAN_API_KEY = apiKey;
   }
 
   let options: SpawnSyncOptionsWithStringEncoding = {

--- a/src/test/suite/lib/run-ggshield.test.ts
+++ b/src/test/suite/lib/run-ggshield.test.ts
@@ -1,0 +1,42 @@
+import * as simple from "simple-mock";
+import * as childProcess from "child_process";
+import * as runGGShield from "../../../lib/run-ggshield";
+import assert = require("assert");
+import { GGShieldConfiguration } from "../../../lib/ggshield-configuration";
+
+suite("runGGShieldCommand", () => {
+  let spawnSyncMock: simple.Stub<Function>;
+
+  setup(() => {
+    spawnSyncMock = simple.mock(childProcess, "spawnSync"); // Mock spawnSync
+  });
+
+  teardown(() => {
+    simple.restore();
+  });
+
+  test("Global env variables are set correctly", async () => {
+    process.env.TEST_GLOBAL_VAR = "GlobalValue";
+
+    const spawnSyncSpy = simple.mock(childProcess, "spawnSync");
+    runGGShield.runGGShieldCommand(
+      {
+        ggshieldPath: "path/to/ggshield",
+        apiUrl: "",
+        apiKey: "",
+      } as GGShieldConfiguration,
+      []
+    );
+
+    // Assert that spawnSync was called
+    assert(spawnSyncSpy.called, "spawnSync should be called once");
+
+    // Check the arguments passed to spawnSync
+    const spawnSyncArgs = spawnSyncSpy.lastCall.args;
+    const options = spawnSyncArgs[2];
+    assert.strictEqual(options.env.TEST_GLOBAL_VAR, "GlobalValue");
+
+    simple.restore();
+    delete process.env.TEST_GLOBAL_VAR;
+  });
+});


### PR DESCRIPTION
How to test this : 
- Add 
  ```
  "env": {
    "TEST": "test"
  }``` to file launch.json so the env variable is passed when you launch the extension in debug mode 
- Log the `options.env` argument
- Assert that TEST is passed correctly