### PR TITLE
Add optional 'allow self signed' option in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Your API Key"
+        },
+        "gitguardian.allowSelfSigned": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Allow Self Signed Certificates"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,10 @@ import {
   scanFile,
   showAPIQuota,
 } from "./lib/ggshield-api";
-import { getConfiguration, setApiKey } from "./lib/ggshield-configuration";
+import {
+  getConfiguration,
+  setApiKey,
+} from "./lib/ggshield-configuration-utils";
 import {
   ExtensionContext,
   Uri,

--- a/src/gitguardian-interface/gitguardian-status-bar.ts
+++ b/src/gitguardian-interface/gitguardian-status-bar.ts
@@ -46,7 +46,11 @@ function getStatusBarConfig(status: StatusBarStatus): StatusBarConfig {
         command: "gitguardian.openSidebar",
       };
     case StatusBarStatus.ready:
-      return { text: "GitGuardian is ready", color: "statusBar.foreground" };
+      return {
+        text: "GitGuardian is ready",
+        color: "statusBar.foreground",
+        command: "gitguardian.openSidebar",
+      };
     case StatusBarStatus.scanning:
       return {
         text: "GitGuardian - Scanning...",

--- a/src/lib/ggshield-configuration-utils.ts
+++ b/src/lib/ggshield-configuration-utils.ts
@@ -24,9 +24,9 @@ export function getConfiguration(
     ggshieldPath
       ? ggshieldPath
       : getBinaryAbsolutePath(os.platform(), os.arch(), context),
-    apiUrl ? apiUrl : apiUrlDefault,
-    apiKey ? apiKey : "",
-    allowSelfSigned ? allowSelfSigned : false
+    apiUrl || apiUrlDefault,
+    apiKey || "",
+    allowSelfSigned || false
   );
 }
 

--- a/src/lib/ggshield-configuration-utils.ts
+++ b/src/lib/ggshield-configuration-utils.ts
@@ -1,0 +1,38 @@
+import { getBinaryAbsolutePath } from "./ggshield-resolver-utils";
+import { ExtensionContext, workspace } from "vscode";
+import * as os from "os";
+import { GGShieldConfiguration } from "./ggshield-configuration";
+
+const apiUrlDefault = "https://dashboard.gitguardian.com/";
+
+/**
+ * Retrieve configuration from settings
+ *
+ * TODO: Check with Mathieu if this behaviour is expected
+ * @returns {GGShieldConfiguration} from the extension settings
+ */
+export function getConfiguration(
+  context: ExtensionContext
+): GGShieldConfiguration {
+  const config = workspace.getConfiguration("gitguardian");
+
+  const ggshieldPath: string | undefined = config.get("GGShieldPath");
+  const apiUrl: string | undefined = config.get("apiUrl");
+  const apiKey: string | undefined = config.get("apiKey");
+  const allowSelfSigned: boolean = config.get("allowSelfSigned", false);
+  return new GGShieldConfiguration(
+    ggshieldPath
+      ? ggshieldPath
+      : getBinaryAbsolutePath(os.platform(), os.arch(), context),
+    apiUrl ? apiUrl : apiUrlDefault,
+    apiKey ? apiKey : "",
+    allowSelfSigned ? allowSelfSigned : false
+  );
+}
+
+export function setApiKey(
+  configuration: GGShieldConfiguration,
+  apiKey: string | undefined
+): void {
+  configuration.apiKey = apiKey ? apiKey : "";
+}

--- a/src/lib/ggshield-configuration.ts
+++ b/src/lib/ggshield-configuration.ts
@@ -8,15 +8,18 @@ export class GGShieldConfiguration {
   ggshieldPath: string;
   apiUrl: string;
   apiKey: string;
+  allowSelfSigned: boolean;
 
   constructor(
     ggshieldPath: string = "",
     apiUrl: string = "",
-    apiKey: string = ""
+    apiKey: string = "",
+    allowSelfSigned: boolean = false
   ) {
     this.ggshieldPath = ggshieldPath;
     this.apiUrl = apiUrl;
     this.apiKey = apiKey;
+    this.allowSelfSigned = allowSelfSigned;
   }
 }
 
@@ -34,13 +37,15 @@ export function getConfiguration(
   const ggshieldPath: string | undefined = config.get("GGShieldPath");
   const apiUrl: string | undefined = config.get("apiUrl");
   const apiKey: string | undefined = config.get("apiKey");
+  const allowSelfSigned: boolean = config.get("allowSelfSigned", false);
 
   return new GGShieldConfiguration(
     ggshieldPath
       ? ggshieldPath
       : getBinaryAbsolutePath(os.platform(), os.arch(), context),
     apiUrl ? apiUrl : apiUrlDefault,
-    apiKey ? apiKey : ""
+    apiKey ? apiKey : "",
+    allowSelfSigned ? allowSelfSigned : false
   );
 }
 

--- a/src/lib/ggshield-configuration.ts
+++ b/src/lib/ggshield-configuration.ts
@@ -1,9 +1,3 @@
-import { getBinaryAbsolutePath } from "./ggshield-resolver-utils";
-import { ExtensionContext, workspace } from "vscode";
-import * as os from "os";
-
-const apiUrlDefault = "https://dashboard.gitguardian.com/";
-
 export class GGShieldConfiguration {
   ggshieldPath: string;
   apiUrl: string;
@@ -21,37 +15,4 @@ export class GGShieldConfiguration {
     this.apiKey = apiKey;
     this.allowSelfSigned = allowSelfSigned;
   }
-}
-
-/**
- * Retrieve configuration from settings
- *
- * TODO: Check with Mathieu if this behaviour is expected
- * @returns {GGShieldConfiguration} from the extension settings
- */
-export function getConfiguration(
-  context: ExtensionContext
-): GGShieldConfiguration {
-  const config = workspace.getConfiguration("gitguardian");
-
-  const ggshieldPath: string | undefined = config.get("GGShieldPath");
-  const apiUrl: string | undefined = config.get("apiUrl");
-  const apiKey: string | undefined = config.get("apiKey");
-  const allowSelfSigned: boolean = config.get("allowSelfSigned", false);
-
-  return new GGShieldConfiguration(
-    ggshieldPath
-      ? ggshieldPath
-      : getBinaryAbsolutePath(os.platform(), os.arch(), context),
-    apiUrl ? apiUrl : apiUrlDefault,
-    apiKey ? apiKey : "",
-    allowSelfSigned ? allowSelfSigned : false
-  );
-}
-
-export function setApiKey(
-  configuration: GGShieldConfiguration,
-  apiKey: string | undefined
-): void {
-  configuration.apiKey = apiKey ? apiKey : "";
 }

--- a/src/lib/run-ggshield.ts
+++ b/src/lib/run-ggshield.ts
@@ -41,6 +41,10 @@ export function runGGShieldCommand(
   if (workspace.workspaceFolders?.length || 0 > 0) {
     options["cwd"] = workspace.workspaceFolders![0].uri.fsPath;
   }
+  // if allowSelfSigned is enabled, add the --allow-self-signed flag
+  if (configuration.allowSelfSigned) {
+    args = ["--allow-self-signed"].concat(args);
+  }
   let proc = spawnSync(ggshieldPath, args, options);
 
   return proc;

--- a/src/test/suite/lib/ggshield-configuration-utils.test.ts
+++ b/src/test/suite/lib/ggshield-configuration-utils.test.ts
@@ -1,24 +1,14 @@
 import * as simple from "simple-mock";
 import assert = require("assert");
 import { ExtensionContext, workspace } from "vscode";
-import * as GGShieldConfiguration from "../../../lib/ggshield-configuration";
 import { getConfiguration } from "../../../lib/ggshield-configuration-utils";
 
 suite("getConfiguration", () => {
   let getConfigurationMock: simple.Stub<Function>;
-  let constructorMock: simple.Stub<Function>;
-  let context: Partial<ExtensionContext>;
 
   setup(() => {
     // Mock workspace.getConfiguration
     getConfigurationMock = simple.mock(workspace, "getConfiguration");
-
-    // Mock the GGShieldConfiguration constructor globally
-    constructorMock = simple.mock(
-      GGShieldConfiguration,
-      "GGShieldConfiguration"
-    );
-    context = {} as ExtensionContext;
   });
 
   teardown(() => {
@@ -42,25 +32,18 @@ suite("getConfiguration", () => {
         }
       },
     });
-    constructorMock.returnWith({});
-
-    getConfiguration(context as ExtensionContext);
+    const configuration = getConfiguration({} as ExtensionContext);
 
     // Assert both workspace.getConfiguration  and GGShieldConfiguration constructor were called
     assert(
       getConfigurationMock.called,
       "getConfiguration should be called once"
     );
-    assert(
-      constructorMock.called,
-      "GGShieldConfiguration constructor should be called once"
-    );
 
-    // Check the arguments passed to GGShieldConfiguration constructor
-    const ggshieldConfigurationArgs = constructorMock.lastCall.args;
-    assert.strictEqual(ggshieldConfigurationArgs[0], "path/to/ggshield");
-    assert.strictEqual(ggshieldConfigurationArgs[1], "https://custom-url.com");
-    assert.strictEqual(ggshieldConfigurationArgs[2], "test-api-key");
-    assert.strictEqual(ggshieldConfigurationArgs[3], true);
+    // Assert that the configuration has the expected values
+    assert.strictEqual(configuration.ggshieldPath, "path/to/ggshield");
+    assert.strictEqual(configuration.apiUrl, "https://custom-url.com");
+    assert.strictEqual(configuration.apiKey, "test-api-key");
+    assert.strictEqual(configuration.allowSelfSigned, true);
   });
 });

--- a/src/test/suite/lib/ggshield-configuration-utils.test.ts
+++ b/src/test/suite/lib/ggshield-configuration-utils.test.ts
@@ -1,0 +1,66 @@
+import * as simple from "simple-mock";
+import assert = require("assert");
+import { ExtensionContext, workspace } from "vscode";
+import * as GGShieldConfiguration from "../../../lib/ggshield-configuration";
+import { getConfiguration } from "../../../lib/ggshield-configuration-utils";
+
+suite("getConfiguration", () => {
+  let getConfigurationMock: simple.Stub<Function>;
+  let constructorMock: simple.Stub<Function>;
+  let context: Partial<ExtensionContext>;
+
+  setup(() => {
+    // Mock workspace.getConfiguration
+    getConfigurationMock = simple.mock(workspace, "getConfiguration");
+
+    // Mock the GGShieldConfiguration constructor globally
+    constructorMock = simple.mock(
+      GGShieldConfiguration,
+      "GGShieldConfiguration"
+    );
+    context = {} as ExtensionContext;
+  });
+
+  teardown(() => {
+    simple.restore();
+  });
+
+  test("Vscode settings are correctly read", async () => {
+    getConfigurationMock.returnWith({
+      get: (key: string) => {
+        if (key === "GGShieldPath") {
+          return "path/to/ggshield";
+        }
+        if (key === "apiUrl") {
+          return "https://custom-url.com";
+        }
+        if (key === "apiKey") {
+          return "test-api-key";
+        }
+        if (key === "allowSelfSigned") {
+          return true;
+        }
+      },
+    });
+    constructorMock.returnWith({});
+
+    getConfiguration(context as ExtensionContext);
+
+    // Assert both workspace.getConfiguration  and GGShieldConfiguration constructor were called
+    assert(
+      getConfigurationMock.called,
+      "getConfiguration should be called once"
+    );
+    assert(
+      constructorMock.called,
+      "GGShieldConfiguration constructor should be called once"
+    );
+
+    // Check the arguments passed to GGShieldConfiguration constructor
+    const ggshieldConfigurationArgs = constructorMock.lastCall.args;
+    assert.strictEqual(ggshieldConfigurationArgs[0], "path/to/ggshield");
+    assert.strictEqual(ggshieldConfigurationArgs[1], "https://custom-url.com");
+    assert.strictEqual(ggshieldConfigurationArgs[2], "test-api-key");
+    assert.strictEqual(ggshieldConfigurationArgs[3], true);
+  });
+});

--- a/src/test/suite/lib/run-ggshield.test.ts
+++ b/src/test/suite/lib/run-ggshield.test.ts
@@ -17,8 +17,6 @@ suite("runGGShieldCommand", () => {
 
   test("Global env variables are set correctly", async () => {
     process.env.TEST_GLOBAL_VAR = "GlobalValue";
-
-    const spawnSyncSpy = simple.mock(childProcess, "spawnSync");
     runGGShield.runGGShieldCommand(
       {
         ggshieldPath: "path/to/ggshield",
@@ -29,14 +27,49 @@ suite("runGGShieldCommand", () => {
     );
 
     // Assert that spawnSync was called
-    assert(spawnSyncSpy.called, "spawnSync should be called once");
+    assert(spawnSyncMock.called, "spawnSync should be called once");
 
     // Check the arguments passed to spawnSync
-    const spawnSyncArgs = spawnSyncSpy.lastCall.args;
+    const spawnSyncArgs = spawnSyncMock.lastCall.args;
     const options = spawnSyncArgs[2];
     assert.strictEqual(options.env.TEST_GLOBAL_VAR, "GlobalValue");
 
-    simple.restore();
     delete process.env.TEST_GLOBAL_VAR;
+  });
+
+  const testCasesAllowSelfSigned = [
+    {
+      allowSelfSigned: true,
+      description:
+        "GGshield is called with flag --allow-self-signed when allowSelfSigned is true",
+    },
+    {
+      allowSelfSigned: false,
+      description:
+        "GGshield is not called with flag --allow-self-signed when allowSelfSigned is false",
+    },
+  ];
+
+  testCasesAllowSelfSigned.forEach(({ allowSelfSigned, description }) => {
+    test(description, async () => {
+      process.env.TEST_GLOBAL_VAR = "GlobalValue";
+
+      runGGShield.runGGShieldCommand(
+        {
+          ggshieldPath: "path/to/ggshield",
+          apiUrl: "",
+          apiKey: "",
+          allowSelfSigned: allowSelfSigned,
+        } as GGShieldConfiguration,
+        []
+      );
+
+      assert(spawnSyncMock.called, "spawnSync should be called once");
+
+      const spawnSyncArgs = spawnSyncMock.lastCall.args;
+      const args = spawnSyncArgs[1];
+
+      assert.strictEqual(args.includes("--allow-self-signed"), allowSelfSigned);
+    });
   });
 });

--- a/src/test/suite/lib/run-ggshield.test.ts
+++ b/src/test/suite/lib/run-ggshield.test.ts
@@ -61,7 +61,7 @@ suite("runGGShieldCommand", () => {
           apiKey: "",
           allowSelfSigned: allowSelfSigned,
         } as GGShieldConfiguration,
-        []
+        ["test"]
       );
 
       assert(spawnSyncMock.called, "spawnSync should be called once");
@@ -69,7 +69,7 @@ suite("runGGShieldCommand", () => {
       const spawnSyncArgs = spawnSyncMock.lastCall.args;
       const args = spawnSyncArgs[1];
 
-      assert.strictEqual(args.includes("--allow-self-signed"), allowSelfSigned);
+      assert.strictEqual(args[0] === "--allow-self-signed", allowSelfSigned);
     });
   });
 });


### PR DESCRIPTION
### What has been done
Add "Allow Self Signed" option in settings (flag). The option is set to false by default. If the option is activated, ggshield command are run with option `--allow-self-signed`

Best reviewed _commit-by-commit_
- [chore(status-bar): Add click event for 'ready' state](https://github.com/GitGuardian/gitguardian-vscode/pull/53/commits/96a9412dc1d7a3f186846eec5562e5978609f7cb): Small refacto, when clicking on statusBar on state 'ready', it now opens the sidebar
- [feat(ggshield-configuration): Add optional 'allow self signed' option for certificates](https://github.com/GitGuardian/gitguardian-vscode/pull/53/commits/7a1daa323540434f0d4540567f5cecf18f804912): Add an option 'Allow self signed' in gitguardian settings. Run ggshield calls with option `--allow-self-signed` if the option is activated
- [feat(ggshield-configuration): Add test for GGshieldConfiguration](https://github.com/GitGuardian/gitguardian-vscode/pull/53/commits/0efc13ceb231e46bd3ceba34fbd56c611c80753a): Reorganize ggshield-configuration-ts, by splitting into 2 files, making mocking possible. Add a test for getConfiguration() ensuring that we are reading vscode settings correctly
- [feat(run-ggshield): Add test for '--allow-self-signed' flag in ggshield calls](https://github.com/GitGuardian/gitguardian-vscode/pull/53/commits/d2070584e59f4d638af93b47a98fdbc3ddd5616b): Add test specifically for runGGshieldCommand()

Note: At first I had the following bug: when launching the extension with self-signed certificate without the flag activated, the extension was prompting for logging in the statusBar but Side panel showed 'extension is active'. But now, I can't reproduce. If you are experiencing this bug please let me know so we can investigate.

### How to test
- Set up a local proxy with `mitmproxy`
- Launch the extension -> everything should work as intended
- Activate flag 'Allow Self Signed' -> everything should work as intended
- Add global variable `htpps_proxy=http://localhost:8080` (or else depending on your port), and **restart the extension**
- Flag 'Allow Self Signed' is activated -> everything should work as intended
- Flag 'Allow Self Signed' is deactivated -> the extension should not work 
