### PR TITLE
style: add category property to commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,35 +55,43 @@
     "commands": [
       {
         "command": "gitguardian.quota",
-        "title": "gitguardian: Show quota"
+        "title": "Show quota",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.ignore",
-        "title": "gitguardian: Ignore last found incidents"
+        "title": "Ignore last found incidents",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.authenticate",
-        "title": "gitguardian: Authenticate"
+        "title": "Authenticate",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.logout",
-        "title": "gitguardian: logout"
+        "title": "Logout",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.showOutput",
-        "title": "Show Output"
+        "title": "Show Output",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.openSidebar",
-        "title": "Open Sidebar"
+        "title": "Open Sidebar",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.openProblems",
-        "title": "Open Problems"
+        "title": "Open Problems",
+        "category": "GitGuardian"
       },
       {
         "command": "gitguardian.refreshQuota",
         "title": "Refresh Quota",
+        "category": "GitGuardian",
         "icon": {
           "light": "images/refresh-light.svg",
           "dark": "images/refresh-dark.svg"

--- a/package.json
+++ b/package.json
@@ -112,19 +112,19 @@
         {
           "type": "webview",
           "id": "gitguardianView",
-          "name": "gitguardian"
+          "name": "GitGuardian"
         },
         {
           "type": "webview",
           "id": "gitguardianRemediationMessageView",
-          "name": "remediation message",
+          "name": "Remediation message",
           "collapsed": true,
           "when": "isAuthenticated == true"
         },
         {
           "type": "webview",
           "id": "gitguardianQuotaView",
-          "name": "quota",
+          "name": "Quota",
           "collapsed": true,
           "when": "isAuthenticated == true"
         }


### PR DESCRIPTION
## Context

The display of the commands was not standardized: some commands were not prepended by GitGuardian, and the others were using _gitguardian_ instead of _GitGuardian_.

![CleanShot 2024-11-13 at 11 26 57@2x](https://github.com/user-attachments/assets/057fc505-f7c5-4f3d-911a-7035d3f03f77)

## What has been done

Update `package.json` to group GitGuardian commands into the `GitGuardian` category.

## Validation

Open the command palette and verify that GitGuardian commands are prepended by _GitGuardian:_


