### PR TITLE
Improve multimatch management

### DIFF
--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1,12 +1,9 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export interface Occurrence {
   type: string;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   line_start: number;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   index_start: number;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   line_end: number;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   index_end: number;
 }
 
@@ -23,13 +20,9 @@ export interface Incident {
   type: string;
   occurrences: Occurrence[];
   validity: Validity;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   ignore_sha: string;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   known_secret: boolean;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   incident_url: string;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   total_occurrences: number;
 }
 
@@ -41,6 +34,5 @@ export interface EntityWithIncidents {
  * JSON response from ggshield scan command
  */
 export interface GGShieldScanResults {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   entities_with_incidents: EntityWithIncidents[];
 }

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -173,15 +173,13 @@ export async function scanFile(
   ]);
 
   if (proc.status === 128 || proc.status === 3) {
-    let errorMessage = "";
-    proc.stderr.split("\n").forEach((stderrLine) => {
-      if (
-        stderrLine.length > 0 &&
-        !stderrLine.includes("Scanning Path...") // ggshield outputs this info message on stderr, ignore it
-      ) {
-        errorMessage += stderrLine + "\n";
-      }
-    });
+    const errorMessage = proc.stderr
+      .split("\n")
+      .filter(
+        (stderrLine) =>
+          stderrLine.length > 0 && !stderrLine.includes("Scanning Path...") // ggshield outputs this info message on stderr, ignore it
+      )
+      .join("\n");
     if (errorMessage.length > 0) {
       window.showErrorMessage(`ggshield: ${errorMessage}`);
       return undefined;
@@ -203,11 +201,11 @@ export async function scanFile(
     updateStatusBarItem(StatusBarStatus.noSecretFound);
     return;
   } else {
-    const results = JSON.parse(proc.stdout);
-    let incidentsDiagnostics: Diagnostic[] = parseGGShieldResults(results);
     updateStatusBarItem(StatusBarStatus.secretFound);
-    diagnosticCollection.set(fileUri, incidentsDiagnostics);
   }
+  const results = JSON.parse(proc.stdout);
+  let incidentsDiagnostics: Diagnostic[] = parseGGShieldResults(results);
+  diagnosticCollection.set(fileUri, incidentsDiagnostics);
 }
 
 export async function loginGGShield(

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -39,3 +39,48 @@ export const scanResultsWithIncident = `{
     "total_occurrences":1,
     "secrets_engine_version":"2.96.0"
     }`;
+
+export const scanResultsWithUriIncident = `{
+  "id": "test.py",
+  "type": "path_scan",
+  "entities_with_incidents": [
+    {
+      "mode": "FILE",
+      "filename": "test.py",
+      "incidents": [
+        {
+          "policy": "Secrets detection",
+          "occurrences": [
+            {
+              "match": "postgres:************************************4/thegift",
+              "type": "connection_uri",
+              "line_start": 1,
+              "line_end": 1,
+              "index_start": 16,
+              "index_end": 70
+            },
+            {
+              "match": "po****es",
+              "type": "scheme",
+              "line_start": 1,
+              "line_end": 1,
+              "index_start": 16,
+              "index_end": 24
+            }
+          ],
+          "type": "PostgreSQL Credentials",
+          "validity": "failed_to_check",
+          "ignore_sha": "981de92451ea2b27f7a163d39c92b566de7cdcc52280fdd9cf7b331d6d53ad86",
+          "total_occurrences": 1,
+          "incident_url": "",
+          "known_secret": false
+        }
+      ],
+      "total_incidents": 1,
+      "total_occurrences": 1
+    }
+  ],
+  "total_incidents": 1,
+  "total_occurrences": 1,
+  "secrets_engine_version": "2.126.0"
+}`;

--- a/src/test/suite/lib/ggshield-api.test.ts
+++ b/src/test/suite/lib/ggshield-api.test.ts
@@ -78,7 +78,7 @@ suite("scanFile", () => {
       statusBar.StatusBarStatus.ignoredFile
     );
   });
-  
+
   const errorCodes = [128, 3];
   errorCodes.forEach((code) => {
     test(`displays an error message if the scan command fails with error code ${code}`, async () => {
@@ -88,11 +88,15 @@ suite("scanFile", () => {
         stderr: "Error",
       });
 
-      await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
+      await scanFile(
+        "test.py",
+        Uri.file("test.py"),
+        {} as GGShieldConfiguration
+      );
 
       // The error message is displayed
       assert.strictEqual(errorMessageMock.callCount, 1);
-      assert.strictEqual(errorMessageMock.lastCall.args[0], "ggshield: Error\n");
+      assert.strictEqual(errorMessageMock.lastCall.args[0], "ggshield: Error");
     });
   });
 

--- a/src/test/suite/lib/ggshield-api.test.ts
+++ b/src/test/suite/lib/ggshield-api.test.ts
@@ -46,7 +46,7 @@ suite("scanFile", () => {
 
   test("successfully scans a file with incidents", async () => {
     runGGShieldCommandMock.returnWith({
-      status: 0,
+      status: 1,
       stdout: scanResultsWithIncident,
       stderr: "",
     });
@@ -78,19 +78,22 @@ suite("scanFile", () => {
       statusBar.StatusBarStatus.ignoredFile
     );
   });
+  
+  const errorCodes = [128, 3];
+  errorCodes.forEach((code) => {
+    test(`displays an error message if the scan command fails with error code ${code}`, async () => {
+      runGGShieldCommandMock.returnWith({
+        status: code,
+        stdout: "",
+        stderr: "Error",
+      });
 
-  test("displays an error message if the scan command fails", async () => {
-    runGGShieldCommandMock.returnWith({
-      status: 1,
-      stdout: "",
-      stderr: "Error",
+      await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
+
+      // The error message is displayed
+      assert.strictEqual(errorMessageMock.callCount, 1);
+      assert.strictEqual(errorMessageMock.lastCall.args[0], "ggshield: Error\n");
     });
-
-    await scanFile("test.py", Uri.file("test.py"), {} as GGShieldConfiguration);
-
-    // The error message is displayed
-    assert.strictEqual(errorMessageMock.callCount, 1);
-    assert.strictEqual(errorMessageMock.lastCall.args[0], "ggshield: Error\n");
   });
 
   test("ignores the 'ignored file cannot be scanned' error", async () => {

--- a/src/test/suite/results-parser.test.ts
+++ b/src/test/suite/results-parser.test.ts
@@ -1,50 +1,18 @@
 import * as assert from "assert";
 
 import { parseGGShieldResults } from "../../lib/ggshield-results-parser";
-import { window, DiagnosticSeverity } from "vscode";
-
-const results = `{
-"id":"/Users/paulindenaurois/Development/gitguardian/ggshield-vscode-extension/sample_files/test.py",
-"type":"path_scan",
-"entities_with_incidents":[
-   {
-      "mode":"FILE",
-      "filename":"/Users/paulindenaurois/Development/gitguardian/ggshield-vscode-extension/sample_files/test.py",
-      "incidents":[
-         {
-            "policy":"Secrets detection",
-            "occurrences":[
-               {
-                  "match":"DDACC73DdB04********************************************057c78317C39",
-                  "type":"apikey",
-                  "line_start":4,
-                  "line_end":4,
-                  "index_start":11,
-                  "index_end":79,
-                  "pre_line_start":4,
-                  "pre_line_end":4
-               }
-            ],
-            "type":"Generic High Entropy Secret",
-            "validity":"no_checker",
-            "ignore_sha":"38353eb1a2aac5b24f39ed67912234d4b4a2e23976d504a88b28137ed2b9185e",
-            "total_occurrences":1,
-            "incident_url":"",
-            "known_secret":false
-         }
-      ],
-      "total_incidents":1,
-      "total_occurrences":1
-   }
-],
-"total_incidents":1,
-"total_occurrences":1,
-"secrets_engine_version":"2.96.0"
-}`;
+import { DiagnosticSeverity } from "vscode";
+import {
+  scanResultsNoIncident,
+  scanResultsWithIncident,
+  scanResultsWithUriIncident,
+} from "../constants";
 
 suite("parseGGShieldResults", () => {
   test("Should parse ggshield scan output", () => {
-    const diagnostics = parseGGShieldResults(JSON.parse(results));
+    const diagnostics = parseGGShieldResults(
+      JSON.parse(scanResultsWithIncident)
+    );
     assert.strictEqual(diagnostics.length, 1);
     const diagnostic = diagnostics[0];
     assert.ok(diagnostic.message.includes("apikey"));
@@ -56,9 +24,21 @@ suite("parseGGShieldResults", () => {
     assert.strictEqual(diagnostic.severity, DiagnosticSeverity.Warning);
   });
 
+  test("Should return an empty array if there are no incidents", () => {
+    const diagnostics = parseGGShieldResults(JSON.parse(scanResultsNoIncident));
+    assert.strictEqual(diagnostics.length, 0);
+  });
+
   test("Should return an empty array on an invalid ggshield output", () => {
     const diagnostics = parseGGShieldResults(JSON.parse("{}"));
-
     assert.strictEqual(diagnostics.length, 0);
+  });
+
+  test("Should only return the 'connection_uri' match if the secret is an URI", () => {
+    const diagnostics = parseGGShieldResults(
+      JSON.parse(scanResultsWithUriIncident)
+    );
+    assert.strictEqual(diagnostics.length, 1);
+    assert.ok(diagnostics[0].message.includes("connection_uri"));
   });
 });


### PR DESCRIPTION
## Context

This PR changes the number of problems created, only for URIs. The decision behind it is described here:

For example:
```
username= ....
password= ....
```
Both matches must be underlined, and it's better if there is one problem per match. If the matches are very far away, it can add context. 

Also, it would be hard to change this behavior since it uses the Vscode API which works that way (one problem underlined <-> one problem in the problem output). Changing this behavior would be much more complex, and it doesn't add much. 


However for URIs:
```
CONNECTION_URI="postgres://postgres:m42ploz2wd@something.com:5434/something"
```
Here, there are technically 5 matches: "scheme", "username", "password", "host" and "connection_uri". Since "connection_uri" represents the whole string, it would make sense to only keep this match, and not create 5 problems in the problem output, as they all link to the same position in the file. 

## What has been done
- [fix(scanFile): Refacto scanFile function to use status code](https://github.com/GitGuardian/gitguardian-vscode/pull/56/commits/09949e8c4dc316adfe73f1d14546ff97c47d3728) : small refacto of the scanFile function for better consistency in the project. 
for context : 
![image](https://github.com/user-attachments/assets/0d7f88d3-9c15-4beb-870d-0d36b8cefab0)
- [feat(result_parser): Better parsing of URI secrets](https://github.com/GitGuardian/gitguardian-vscode/pull/56/commits/c4d57334874501aaa2795bc3f7152ea4fbd5e0d2) : only return the "connection_uri" match if there is one

## Validation

<!--
Describe how to validate your changes.

For example:

- Clone repository https://example.com/git/repo.
- cd into `repo`.
- it should do x.
-->

## PR check list

- [x] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry. 

