### PR TITLE
fix: use API urls from official doc

### DIFF
--- a/src/lib/ggshield-configuration.ts
+++ b/src/lib/ggshield-configuration.ts
@@ -9,8 +9,15 @@ export class GGShieldConfiguration {
     allowSelfSigned: boolean = false
   ) {
     this.ggshieldPath = ggshieldPath;
-    this.apiUrl = apiUrl;
     this.allowSelfSigned = allowSelfSigned;
+    if (apiUrl === "https://api.gitguardian.com/v1") {
+      this.apiUrl = "https://dashboard.gitguardian.com/v1";
+  } else if (apiUrl === "https://api.eu1.gitguardian.com/v1") {
+    this.apiUrl = "https://dashboard.eu1.gitguardian.com/v1";
+  }
+  else {
+    this.apiUrl = apiUrl;
+  }
   }
 }
 

--- a/src/test/suite/lib/ggshield-configuration-utils.test.ts
+++ b/src/test/suite/lib/ggshield-configuration-utils.test.ts
@@ -40,4 +40,27 @@ suite("getConfiguration", () => {
     assert.strictEqual(configuration.apiUrl, "https://custom-url.com");
     assert.strictEqual(configuration.allowSelfSigned, true);
   });
+
+  test("API url is correctly replaced with dashboard urlg for EU customers", () => {
+    const context = {} as ExtensionContext;
+    simple.mock(context, "asAbsolutePath").returnWith("");
+    getConfigurationMock.returnWith({
+      get: (key: string) => {
+        if (key === "apiUrl") {
+          return "https://api.eu1.gitguardian.com/v1";
+        }
+      },
+    });
+    const configuration = getConfiguration(context);
+
+    // Assert both workspace.getConfiguration  and GGShieldConfiguration constructor were called
+    assert(
+      getConfigurationMock.called,
+      "getConfiguration should be called once"
+    );
+
+    // Assert that the configuration has the expected values
+    assert.strictEqual(configuration.apiUrl, "https://dashboard.eu1.gitguardian.com/v1");
+  });
+
 });


### PR DESCRIPTION
## Context

API url to use isn't consistent with [GitGuardian API documentation](https://api.gitguardian.com/docs). Thus when users try to set API url param to `https://api.gitguardian.com/v1` or `https://api.eu1.gitguardian.com/v1`, login fail.

## What has been done

When a url from official documentation is provided, we replace it with its matching one working with GGShield.

## Validation
- checkout this branch
- launch the extension 
- set API url param to `https://api.gitguardian.com/v1` or `https://api.eu1.gitguardian.com/v1`
- reload window
- you should have logged in perfectly

## PR check list

- [x] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry. 
@salome-voltz @gg-jonathangriffe is there a way to add a changelog entry? Apart from updating `CHANGELOG.md` in the release PR?

