### PR TITLE
chore: fix changelog for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.7.0]
 
-### Fixed
+### Added
 
 - Updated to [ggshield 1.36.0](https://github.com/GitGuardian/ggshield/releases/v1.36.0).
 


### PR DESCRIPTION
[Release is already out](https://github.com/GitGuardian/gitguardian-vscode/releases) but I'm just fixing the typo in in the changelog