### PR TITLE
chore: handle windows VM running on macOS silicon

### DIFF
--- a/src/lib/ggshield-resolver-utils.ts
+++ b/src/lib/ggshield-resolver-utils.ts
@@ -100,6 +100,10 @@ export function computeGGShieldFolderName(
       break;
     case "arm64":
       archString = "arm64";
+      // win32 + arm64 -> rely on x86_64 emulation on ARM
+      if (platform === "win32") {
+        archString = "x86_64";
+      }
       break;
     default:
       console.log(`Unsupported architecture: ${arch}`);

--- a/src/test/suite/lib/ggshield-resolver-utils.test.ts
+++ b/src/test/suite/lib/ggshield-resolver-utils.test.ts
@@ -158,6 +158,22 @@ suite("ggshield-resolver-utils", () => {
         ),
       );
     });
+    test("computes correct path for Windows arm64", () => {
+      const result = getGGShieldUtils.computeGGShieldPath(
+        "win32",
+        "arm64",
+        ggshieldFolder,
+        version,
+      );
+      assert.strictEqual(
+        result,
+        path.join(
+          ggshieldFolder,
+          "ggshield-1.0.0-x86_64-pc-windows-msvc",
+          "ggshield.exe",
+        ),
+      );
+    });
 
     test("computes correct path for Linux", () => {
       const result = getGGShieldUtils.computeGGShieldPath(


### PR DESCRIPTION
## Context

GGShield installation was failing on win23 - arm64 architecture. We noticed this when testing the extension on a Windows VM on MacOS silicon.

## What has been done

Fetch the relevant ggshield windows package in that case.

## Validation

Validate manually + with new test case.

## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry. 

