### PR TITLE
feat: Show secret_vaulted in results

### DIFF
--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -24,6 +24,7 @@ export interface Incident {
   known_secret: boolean;
   incident_url: string;
   total_occurrences: number;
+  secret_vaulted: boolean;
 }
 
 export interface EntityWithIncidents {

--- a/src/lib/ggshield-results-parser.ts
+++ b/src/lib/ggshield-results-parser.ts
@@ -34,7 +34,7 @@ const validityDisplayName: Record<Validity, string> = {
  */
 function filterUriOccurrences(occurrences: Occurrence[]): Occurrence[] {
   const uriOccurrence = occurrences.find(
-    ({ type }) => type === "connection_uri"
+    ({ type }) => type === "connection_uri",
   );
   return uriOccurrence ? [uriOccurrence] : occurrences;
 }
@@ -46,7 +46,7 @@ function filterUriOccurrences(occurrences: Occurrence[]): Occurrence[] {
  * @returns incidents diagnostics
  */
 export function parseGGShieldResults(
-  results: GGShieldScanResults
+  results: GGShieldScanResults,
 ): Diagnostic[] {
   let diagnostics: Diagnostic[] = [];
 
@@ -61,7 +61,7 @@ export function parseGGShieldResults(
             (occurrence: Occurrence) => {
               let range = new Range(
                 new Position(occurrence.line_start - 1, occurrence.index_start),
-                new Position(occurrence.line_end - 1, occurrence.index_end)
+                new Position(occurrence.line_end - 1, occurrence.index_end),
               );
               let diagnostic = new Diagnostic(
                 range,
@@ -72,16 +72,17 @@ Validity: ${validityDisplayName[incident.validity]}
 Known by GitGuardian dashboard: ${incident.known_secret ? "YES" : "NO"}
 Total occurrences: ${incident.total_occurrences}
 Incident URL: ${incident.incident_url || "N/A"}
-Secret SHA: ${incident.ignore_sha}`,
-                DiagnosticSeverity.Warning
+Secret SHA: ${incident.ignore_sha}
+Secret in Secrets Manager: ${incident.secret_vaulted ? "YES" : "NO"}`,
+                DiagnosticSeverity.Warning,
               );
 
               diagnostic.source = "gitguardian";
               diagnostics.push(diagnostic);
-            }
+            },
           );
         });
-      }
+      },
     );
   } catch (e) {
     console.error(e);

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -28,7 +28,8 @@ export const scanResultsWithIncident = `{
                 "ignore_sha":"38353eb1a2aac5b24f39ed67912234d4b4a2e23976d504a88b28137ed2b9185e",
                 "total_occurrences":1,
                 "incident_url":"",
-                "known_secret":false
+                "known_secret":false,
+                "secret_vaulted": false
              }
           ],
           "total_incidents":1,

--- a/src/test/suite/results-parser.test.ts
+++ b/src/test/suite/results-parser.test.ts
@@ -11,12 +11,13 @@ import {
 suite("parseGGShieldResults", () => {
   test("Should parse ggshield scan output", () => {
     const diagnostics = parseGGShieldResults(
-      JSON.parse(scanResultsWithIncident)
+      JSON.parse(scanResultsWithIncident),
     );
     assert.strictEqual(diagnostics.length, 1);
     const diagnostic = diagnostics[0];
     assert.ok(diagnostic.message.includes("apikey"));
     assert.ok(diagnostic.message.includes("Generic High Entropy Secret"));
+    assert.ok(diagnostic.message.includes("Secret in Secrets Manager: NO"));
     assert.strictEqual(diagnostic.range.start.line, 3);
     assert.strictEqual(diagnostic.range.start.character, 11);
     assert.strictEqual(diagnostic.range.end.line, 3);
@@ -36,7 +37,7 @@ suite("parseGGShieldResults", () => {
 
   test("Should only return the 'connection_uri' match if the secret is an URI", () => {
     const diagnostics = parseGGShieldResults(
-      JSON.parse(scanResultsWithUriIncident)
+      JSON.parse(scanResultsWithUriIncident),
     );
     assert.strictEqual(diagnostics.length, 1);
     assert.ok(diagnostics[0].message.includes("connection_uri"));


### PR DESCRIPTION
## Context

This MR aims at showing if the secret is in a secret Manager known by GG, by leveraging the new property `is_vaulted` added in GGshield. 

![image](https://github.com/user-attachments/assets/a6d4c063-f435-4819-a8c9-e711568ef19b)


## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry. 

