### PR TITLE
build: bundle ggshield binary with extension

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,17 @@ permissions:
   contents: read
 
 jobs:
-  build_vsix_file:
+  build_vsix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-x64
+          - target: darwin-arm64
+          - target: linux-x64
+          - target: win32-x64
+          - target: win32-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,12 +38,16 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Build extension
+      - name: Build platform-specific VSIX
         run: |
-          vsce package --baseContentUrl https://github.com/GitGuardian/gitguardian-vscode/ --allow-missing-repository
+          vsce package --target ${{ matrix.target }} \
+            --baseContentUrl https://github.com/GitGuardian/gitguardian-vscode/ \
+            --allow-missing-repository
+        env:
+          GGSHIELD_TARGET: ${{ matrix.target }}
 
       - name: Upload extension package
         uses: actions/upload-artifact@v4
         with:
-          name: gitguardian.vsix
+          name: gitguardian-${{ matrix.target }}.vsix
           path: gitguardian-*.vsix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            vscode_target: linux-x64
+          - os: macos-latest
+            vscode_target: darwin-arm64
+          - os: windows-latest
+            vscode_target: win32-x64
 
     steps:
       - name: 👩‍💻 Checkout code
@@ -41,6 +47,10 @@ jobs:
 
       - name: ⚙️ Install dependencies
         run: yarn install
+
+      - name: Download ggshield binary
+        shell: bash
+        run: scripts/download-ggshield.sh --target ${{ matrix.vscode_target }}
 
         # We use xvfb-run on Linux to run tests because we need a display.
         # xvfb-run is not available on macOS, so we use XQuartz instead.

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ out/
 
 # ggshield internal
 ggshield-internal/
+ggshield-bundled/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+scripts/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GitGuardian Secret Security Changelog
 
+## [0.22.0]
+
+### Changed
+
+- `ggshield` binaries are again bundled in the extension.
+- Distribute platform-specific extensions to limit the extension size with bundled `ggshield`.
+
 ## [0.21.0]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "yarn run compile",
+    "vscode:prepublish": "bash scripts/download-ggshield.sh && yarn run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",
@@ -165,12 +165,10 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/adm-zip": "^0.5.7",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "20.2.5",
     "@types/simple-mock": "^0.8.6",
-    "@types/tar": "^6.1.13",
     "@types/vscode": "^1.81.0",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
@@ -181,9 +179,5 @@
     "simple-mock": "^0.8.0",
     "typescript": "^5.1.3"
   },
-  "dependencies": {
-    "adm-zip": "^0.5.16",
-    "axios": "^1.9.0",
-    "tar": "^7.4.3"
-  }
+  "dependencies": {}
 }

--- a/scripts/download-ggshield.sh
+++ b/scripts/download-ggshield.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+VERSION=$(cat "$ROOT_DIR/ggshield_version" | tr -d '[:space:]')
+OUTPUT_DIR="$ROOT_DIR/ggshield-bundled"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--target <vscode-target>] [--force]
+
+Download and stage a ggshield binary for bundling into a platform-specific VSIX.
+
+If --target is omitted, auto-detects from the current OS/arch.
+Skips download if the binary already exists (use --force to re-download).
+
+Supported targets:
+  darwin-x64, darwin-arm64, linux-x64, win32-x64, win32-arm64
+
+The binary is extracted into ggshield-bundled/ at the project root.
+EOF
+    exit 1
+}
+
+detect_target() {
+    local os arch
+    os=$(uname -s)
+    arch=$(uname -m)
+
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64)  echo "darwin-arm64" ;;
+                x86_64) echo "darwin-x64" ;;
+                *)      echo "Error: unsupported macOS architecture: $arch" >&2; exit 1 ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64)  echo "linux-x64" ;;
+                *)       echo "Error: unsupported Linux architecture: $arch (only x86_64 is supported)" >&2; exit 1 ;;
+            esac
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            echo "win32-x64"
+            ;;
+        *)
+            echo "Error: unsupported OS: $os" >&2; exit 1
+            ;;
+    esac
+}
+
+TARGET=""
+FORCE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)
+            TARGET="$2"
+            shift 2
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$TARGET" && -n "${GGSHIELD_TARGET:-}" ]]; then
+    TARGET="$GGSHIELD_TARGET"
+    echo "Using target from GGSHIELD_TARGET: ${TARGET}"
+elif [[ -z "$TARGET" ]]; then
+    TARGET=$(detect_target)
+    echo "Auto-detected target: ${TARGET}"
+fi
+
+# Map VS Code target to ggshield release asset components
+case "$TARGET" in
+    darwin-x64)
+        ASSET_TARGET="x86_64-apple-darwin"
+        ARCHIVE_EXT="tar.gz"
+        BINARY_EXTENSION=""
+        ;;
+    darwin-arm64)
+        ASSET_TARGET="arm64-apple-darwin"
+        ARCHIVE_EXT="tar.gz"
+        BINARY_EXTENSION=""
+        ;;
+    linux-x64)
+        ASSET_TARGET="x86_64-unknown-linux-gnu"
+        ARCHIVE_EXT="tar.gz"
+        BINARY_EXTENSION=""
+        ;;
+    win32-x64|win32-arm64)
+        ASSET_TARGET="x86_64-pc-windows-msvc"
+        ARCHIVE_EXT="zip"
+        BINARY_EXTENSION=".exe"
+        ;;
+    *)
+        echo "Error: unsupported target '$TARGET'" >&2
+        echo "Supported: darwin-x64, darwin-arm64, linux-x64, win32-x64, win32-arm64" >&2
+        exit 1
+        ;;
+esac
+
+ASSET_NAME="ggshield-${VERSION}-${ASSET_TARGET}.${ARCHIVE_EXT}"
+DOWNLOAD_URL="https://github.com/GitGuardian/ggshield/releases/download/v${VERSION}/${ASSET_NAME}"
+
+# Skip if binary already exists (unless --force)
+EXPECTED_BINARY="$OUTPUT_DIR/ggshield${BINARY_EXTENSION}"
+
+if [[ "$FORCE" -eq 0 && -f "$EXPECTED_BINARY" ]]; then
+    echo "ggshield binary already exists at ${EXPECTED_BINARY}, skipping download (use --force to re-download)"
+    exit 0
+fi
+
+echo "Downloading ggshield v${VERSION} for ${TARGET}..."
+echo "  URL: ${DOWNLOAD_URL}"
+
+# Clean up previous bundled binary
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Download to a temp file
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+if ! curl -fSL --retry 3 --retry-delay 5 -o "$TMPFILE" "$DOWNLOAD_URL"; then
+    echo "Error: failed to download ${DOWNLOAD_URL}" >&2
+    echo "Check that ggshield v${VERSION} has a release asset for ${ASSET_TARGET}" >&2
+    exit 1
+fi
+
+# Extract the binary into ggshield-bundled/
+# The archive contains a directory like ggshield-{ver}-{target}/ with the binary inside.
+# We extract and then move contents up so the structure is flat: ggshield-bundled/ggshield
+case "$ARCHIVE_EXT" in
+    tar.gz)
+        tar xzf "$TMPFILE" -C "$OUTPUT_DIR" --strip-components=1
+        ;;
+    zip)
+        # Extract to a temp dir first, then move contents up (strip top-level dir)
+        EXTRACT_TMP=$(mktemp -d)
+        trap 'rm -f "$TMPFILE"; rm -rf "$EXTRACT_TMP"' EXIT
+        unzip -q "$TMPFILE" -d "$EXTRACT_TMP"
+        # Move contents of the single top-level directory into OUTPUT_DIR
+        TOP_DIR=$(ls "$EXTRACT_TMP")
+        mv "$EXTRACT_TMP/$TOP_DIR"/* "$OUTPUT_DIR/"
+        rm -rf "$EXTRACT_TMP"
+        ;;
+esac
+
+# Verify the binary exists
+BINARY="$OUTPUT_DIR/ggshield${BINARY_EXTENSION}"
+
+if [[ ! -f "$BINARY" ]]; then
+    echo "Error: expected binary not found at $BINARY after extraction" >&2
+    echo "Contents of $OUTPUT_DIR:" >&2
+    ls -la "$OUTPUT_DIR" >&2
+    exit 1
+fi
+
+echo "ggshield v${VERSION} staged at ${OUTPUT_DIR}/"
+echo "Binary: ${BINARY}"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ function registerOpenViewsCommands(
 
 export async function activate(context: ExtensionContext) {
   const outputChannel = window.createOutputChannel("GitGuardian");
-  let configuration = await getConfiguration(context, outputChannel);
+  let configuration = getConfiguration(context, outputChannel);
 
   const ggshieldResolver = new GGShieldResolver(
     outputChannel,

--- a/src/lib/ggshield-configuration-utils.ts
+++ b/src/lib/ggshield-configuration-utils.ts
@@ -7,10 +7,10 @@ import { getGGShield } from "./ggshield-resolver-utils";
  * Retrieve configuration from settings
  * @returns {GGShieldConfiguration} from the extension settings
  */
-export async function getConfiguration(
+export function getConfiguration(
   context: ExtensionContext,
   outputChannel: OutputChannel,
-): Promise<GGShieldConfiguration> {
+): GGShieldConfiguration {
   const config = workspace.getConfiguration("gitguardian");
 
   const apiUrl: string | undefined = config.get("apiUrl");
@@ -20,13 +20,7 @@ export async function getConfiguration(
     config.get("allowSelfSigned", false),
   );
 
-  const pathToGGShield: string = await getGGShield(
-    os.platform(),
-    os.arch(),
-    context,
-    outputChannel,
-    insecure,
-  );
+  const pathToGGShield = getGGShield(os.platform(), context, outputChannel);
 
   return new GGShieldConfiguration(pathToGGShield, apiUrl, insecure || false);
 }

--- a/src/lib/ggshield-resolver-utils.ts
+++ b/src/lib/ggshield-resolver-utils.ts
@@ -1,16 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
-import * as tar from "tar";
-import axios, { AxiosRequestConfig } from "axios";
-import { Agent } from "https";
-
-const AdmZip = require("adm-zip");
 import { ExtensionContext, OutputChannel } from "vscode";
-
-const defaultRequestConfig = {
-  headers: { "User-Agent": "GitGuardian-VSCode-Extension" },
-  timeout: 30_000,
-} satisfies AxiosRequestConfig;
 
 /**
  * Get the version of GGShield
@@ -24,229 +14,43 @@ export function getGGShieldVersion(context: ExtensionContext): string {
 }
 
 /**
- * Get the absolute path to GGShield binary. If it doesn't exist, it will be installed.
+ * Get the absolute path to the bundled GGShield binary.
  * @param platform The platform of the user
- * @param arch The architecture of the user
  * @param context The extension context
  * @param outputChannel The output channel to use
  * @returns The absolute path to the GGShield binary
  */
-export async function getGGShield(
+export function getGGShield(
   platform: NodeJS.Platform,
-  arch: string,
   context: ExtensionContext,
   outputChannel: OutputChannel,
-  insecure: boolean,
-): Promise<string> {
-  const version = getGGShieldVersion(context);
-  console.log(`Latest GGShield version: ${version}`);
-  const ggshieldFolder: string = path.join(
-    context.extensionPath,
-    "ggshield-internal",
-  );
-  const ggshieldBinaryPath: string = computeGGShieldPath(
-    platform,
-    arch,
-    ggshieldFolder,
-    version,
-  );
+): string {
+  const bundledPath = getBundledGGShieldPath(platform, context);
 
-  // if exists, return the path
-  if (fs.existsSync(ggshieldBinaryPath)) {
-    outputChannel.appendLine(
-      `Using GGShield v${version}. Checkout https://github.com/GitGuardian/ggshield for more info.`,
+  if (!fs.existsSync(bundledPath)) {
+    throw new Error(
+      `Bundled ggshield binary not found at ${bundledPath}. ` +
+        `This may indicate a corrupted extension installation.`,
     );
-    console.log(`GGShield already exists at ${ggshieldBinaryPath}`);
-    return ggshieldBinaryPath;
   }
-  // empty ggshield folder if exists, and then re-create it
-  if (fs.existsSync(ggshieldFolder)) {
-    fs.rmSync(ggshieldFolder, { recursive: true });
-  }
-  fs.mkdirSync(ggshieldFolder);
-  // install GGShield
-  await installGGShield(platform, arch, ggshieldFolder, version, insecure);
+
+  const version = getGGShieldVersion(context);
   outputChannel.appendLine(
-    `Updated to GGShield v${version}. Checkout https://github.com/GitGuardian/ggshield for more info.`,
+    `Using GGShield v${version}. Checkout https://github.com/GitGuardian/ggshield for more info.`,
   );
-  console.log(`GGShield binary installed at ${ggshieldBinaryPath}`);
-  return ggshieldBinaryPath;
+  return bundledPath;
 }
 
 /**
- * Compute the folder name of the GGShield binary
+ * Get the path to the bundled GGShield binary
  * @param platform The platform of the user
- * @param arch The architecture of the user
- * @param version The version of GGShield
- * @returns The folder name of the GGShield binary
+ * @param context The extension context
+ * @returns The absolute path to the bundled binary
  */
-export function computeGGShieldFolderName(
+export function getBundledGGShieldPath(
   platform: NodeJS.Platform,
-  arch: string,
-  version: string,
+  context: ExtensionContext,
 ): string {
-  let archString: string = "";
-  let platformString: string = "";
-  switch (arch) {
-    case "x64":
-    case "x86":
-      archString = "x86_64";
-      break;
-    case "arm64":
-      archString = "arm64";
-      // win32 + arm64 -> rely on x86_64 emulation on ARM
-      if (platform === "win32") {
-        archString = "x86_64";
-      }
-      break;
-    default:
-      console.log(`Unsupported architecture: ${arch}`);
-      throw new Error(`Unsupported architecture: ${arch}`);
-  }
-  switch (platform) {
-    case "win32":
-      platformString = "pc-windows-msvc";
-      break;
-    case "linux":
-      platformString = "unknown-linux-gnu";
-      break;
-    case "darwin":
-      platformString = "apple-darwin";
-      break;
-    default:
-      console.log(`Unsupported platform - ${platform}`);
-      throw new Error(`Unsupported platform: ${platform}`);
-  }
-  return `ggshield-${version}-${archString}-${platformString}`;
-}
-
-/**
- * Install GGShield: download the executable archive from GitHub and extract it
- * @param platform The platform of the user
- * @param arch The architecture of the user
- * @param ggshieldFolder The folder of the GGShield binary
- * @param version The version of GGShield
- */
-export async function installGGShield(
-  platform: NodeJS.Platform,
-  arch: string,
-  ggshieldFolder: string,
-  version: string,
-  insecure: boolean,
-): Promise<void> {
-  let extension: string = "";
-  switch (platform) {
-    case "win32":
-      extension = "zip";
-      break;
-    case "linux":
-    case "darwin":
-      extension = "tar.gz";
-      break;
-    default:
-      console.log(`Unsupported platform: ${platform}`);
-      throw new Error(`Unsupported platform: ${platform}`);
-  }
-  const fileName: string = `${computeGGShieldFolderName(
-    platform,
-    arch,
-    version,
-  )}.${extension}`;
-  const downloadUrl: string = `https://github.com/GitGuardian/ggshield/releases/download/v${version}/${fileName}`;
-  await downloadGGShieldFromGitHub(
-    fileName,
-    downloadUrl,
-    ggshieldFolder,
-    insecure,
-  );
-  extractGGShieldBinary(path.join(ggshieldFolder, fileName), ggshieldFolder);
-}
-
-/**
- * Extract the GGShield binary
- * @param filePath The path to the GGShield binary
- * @param ggshieldFolder The folder of the GGShield binary
- */
-export function extractGGShieldBinary(
-  filePath: string,
-  ggshieldFolder: string,
-): void {
-  if (filePath.endsWith(".tar.gz")) {
-    tar.x({
-      file: filePath,
-      cwd: ggshieldFolder,
-      sync: true,
-    });
-  } else if (filePath.endsWith(".zip")) {
-    const zip = new AdmZip(filePath);
-    zip.extractAllTo(ggshieldFolder, true);
-  } else {
-    throw new Error(`Unsupported file extension: ${path.extname(filePath)}`);
-  }
-}
-
-/**
- * Download the GGShield binary from GitHub
- * @param fileName The name of the GGShield binary
- * @param downloadUrl The URL of the GGShield binary
- * @param ggshieldFolder The folder of the GGShield binary
- */
-async function downloadGGShieldFromGitHub(
-  fileName: string,
-  downloadUrl: string,
-  ggshieldFolder: string,
-  insecure: boolean,
-): Promise<void> {
-  console.log(`Downloading GGShield from ${downloadUrl}`);
-
-  const instance = insecure
-    ? new Agent({
-        rejectUnauthorized: false,
-      })
-    : undefined;
-
-  const { data } = await axios.get(downloadUrl, {
-    ...defaultRequestConfig,
-    responseType: "arraybuffer",
-    httpsAgent: instance,
-  });
-
-  fs.writeFileSync(path.join(ggshieldFolder, fileName), data);
-  console.log(
-    `GGShield archive downloaded to ${path.join(ggshieldFolder, fileName)}`,
-  );
-}
-
-/**
- * Compute the path to the GGShield binary
- * @param platform The platform of the user
- * @param arch The architecture of the user
- * @param ggshieldFolder The folder of the GGShield binary
- * @param version The version of GGShield
- */
-export function computeGGShieldPath(
-  platform: NodeJS.Platform,
-  arch: string,
-  ggshieldFolder: string,
-  version: string,
-): string {
-  console.log(`Platform: ${platform}; Arch: ${arch}`);
-  let executable: string = "";
-  switch (platform) {
-    case "win32":
-      executable = "ggshield.exe";
-      break;
-    case "linux":
-    case "darwin":
-      executable = "ggshield";
-      break;
-    default:
-      console.log(`Unsupported platform: ${platform}`);
-      throw new Error(`Unsupported platform: ${platform}`);
-  }
-  return path.join(
-    ggshieldFolder,
-    computeGGShieldFolderName(platform, arch, version),
-    executable,
-  );
+  const executable = platform === "win32" ? "ggshield.exe" : "ggshield";
+  return path.join(context.extensionPath, "ggshield-bundled", executable);
 }

--- a/src/test/suite/lib/ggshield-configuration-utils.test.ts
+++ b/src/test/suite/lib/ggshield-configuration-utils.test.ts
@@ -6,13 +6,8 @@ import * as ggshieldResolverUtils from "../../../lib/ggshield-resolver-utils";
 
 suite("getConfiguration", () => {
   let getConfigurationMock: simple.Stub<Function>;
-  let getGGShieldMock: simple.Stub<
-    (
-      platform: NodeJS.Platform,
-      arch: string,
-      context: ExtensionContext,
-    ) => string
-  >;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getGGShieldMock: any;
 
   setup(() => {
     // Mock workspace.getConfiguration
@@ -20,7 +15,7 @@ suite("getConfiguration", () => {
     // Mock getGGShield
     getGGShieldMock = simple
       .mock(ggshieldResolverUtils, "getGGShield")
-      .returnWith(() => "/mock/path/to/ggshield");
+      .returnWith("/mock/path/to/ggshield");
   });
 
   teardown(() => {
@@ -45,7 +40,7 @@ suite("getConfiguration", () => {
     }
   }
 
-  test("Vscode settings are correctly read", async () => {
+  test("Vscode settings are correctly read", () => {
     const context = {} as ExtensionContext;
     const outputChannel = window.createOutputChannel("GitGuardian");
     simple.mock(context, "asAbsolutePath").returnWith("");
@@ -56,7 +51,7 @@ suite("getConfiguration", () => {
         insecure: true,
       } as Record<string, any>),
     );
-    const configuration = await getConfiguration(context, outputChannel);
+    const configuration = getConfiguration(context, outputChannel);
 
     // Assert both workspace.getConfiguration and GGShieldConfiguration constructor were called
     assert(
@@ -68,7 +63,8 @@ suite("getConfiguration", () => {
     assert.strictEqual(configuration.apiUrl, "https://custom-url.com");
     assert.strictEqual(configuration.insecure, true);
   });
-  test("insecure falls back on allowSelfSigned", async () => {
+
+  test("insecure falls back on allowSelfSigned", () => {
     const context = {} as ExtensionContext;
     const outputChannel = window.createOutputChannel("GitGuardian");
     simple.mock(context, "asAbsolutePath").returnWith("");
@@ -78,7 +74,7 @@ suite("getConfiguration", () => {
         allowSelfSigned: true,
       } as Record<string, any>),
     );
-    const configuration = await getConfiguration(context, outputChannel);
+    const configuration = getConfiguration(context, outputChannel);
 
     // Assert that the configuration has the expected values
     assert.strictEqual(configuration.insecure, true);

--- a/src/test/suite/lib/ggshield-resolver-utils.test.ts
+++ b/src/test/suite/lib/ggshield-resolver-utils.test.ts
@@ -1,24 +1,16 @@
 import * as assert from "assert";
 import * as path from "path";
 import * as fs from "fs";
-import * as os from "os";
-import * as tar from "tar";
-const AdmZip = require("adm-zip");
 import * as getGGShieldUtils from "../../../lib/ggshield-resolver-utils";
 import { ExtensionContext, window, OutputChannel } from "vscode";
 
-suite("getGGShield integration tests", async () => {
+suite("getGGShield", () => {
   let tempDir: string;
   let mockContext: ExtensionContext;
-  let version: string;
   let outputChannel: OutputChannel = window.createOutputChannel("GitGuardian");
   const platform = process.platform;
-  const arch = process.arch;
-  let originalLog: (message?: any, ...optionalParams: any[]) => void;
-  let output: string;
 
   setup(() => {
-    // Create temp directory for tests
     tempDir = fs.mkdtempSync(__dirname);
     mockContext = {
       extensionPath: tempDir,
@@ -28,299 +20,77 @@ suite("getGGShield integration tests", async () => {
       path.join(__dirname, "..", "..", "..", "..", "ggshield_version"),
       path.join(tempDir, "ggshield_version"),
     );
-    version = getGGShieldUtils.getGGShieldVersion(mockContext);
-    output = ""; // Reset captured output before each test
-    originalLog = console.log; // Store original console.log
-
-    console.log = (message: string) => {
-      output += message;
-    };
   });
 
   teardown(() => {
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true });
-      console.log = originalLog; // Restore original console.log
     }
   });
 
-  test("returns existing binary path when binary exists", async () => {
-    const binaryPath: string = createFakeBinary(
-      tempDir,
+  test("returns bundled binary path when binary exists", () => {
+    const binaryPath = createFakeBundledBinary(tempDir, platform);
+    const result = getGGShieldUtils.getGGShield(
       platform,
-      arch,
-      version,
-    );
-    const result = await getGGShieldUtils.getGGShield(
-      platform,
-      arch,
       mockContext,
       outputChannel,
-      false,
     );
 
     assert.strictEqual(result, binaryPath);
     assert(fs.existsSync(result));
-    assert(result.includes(version));
-    assert(
-      !output.includes("Updated to GGShield"),
-      "installGGShield should not be called when binary exists",
-    );
   });
 
-  test("installs binary when it doesn't exist", async () => {
-    const expectedBinaryPath: string = getGGShieldUtils.computeGGShieldPath(
-      platform,
-      arch,
-      path.join(tempDir, "ggshield-internal"),
-      version,
-    );
-    assert(!fs.existsSync(expectedBinaryPath));
-
-    const result = await getGGShieldUtils.getGGShield(
-      platform,
-      arch,
-      mockContext,
-      outputChannel,
-      false,
-    );
-
-    assert(fs.existsSync(result));
-    assert.strictEqual(result, expectedBinaryPath);
-    assert(result.includes(version));
-    assert(
-      !output.includes("Updated to GGShield"),
-      "installGGShield should be called once when binary doesn't exist",
-    );
-  });
-
-  test("updates binary when newer version set by ggshield_version file", async () => {
-    const oldBinaryPath: string = createFakeBinary(
-      tempDir,
-      platform,
-      arch,
-      "1.0.0",
-    );
-    const result = await getGGShieldUtils.getGGShield(
-      platform,
-      arch,
-      mockContext,
-      outputChannel,
-      false,
-    );
-
-    assert(fs.existsSync(result));
-    assert(result.includes(version));
-    assert(!fs.existsSync(oldBinaryPath));
-    assert(
-      !output.includes("Updated to GGShield"),
-      "installGGShield should be called once when updating binary",
-    );
+  test("throws when bundled binary does not exist", () => {
+    assert.throws(() => {
+      getGGShieldUtils.getGGShield(platform, mockContext, outputChannel);
+    }, /Bundled ggshield binary not found/);
   });
 });
 
-function createFakeBinary(
+suite("getBundledGGShieldPath", () => {
+  const cases: { platform: NodeJS.Platform; expectedBinary: string }[] = [
+    { platform: "darwin", expectedBinary: "ggshield" },
+    { platform: "linux", expectedBinary: "ggshield" },
+    { platform: "win32", expectedBinary: "ggshield.exe" },
+  ];
+
+  cases.forEach(({ platform, expectedBinary }) => {
+    test(`returns correct path for ${platform}`, () => {
+      const context = {
+        extensionPath: "/ext",
+      } as ExtensionContext;
+
+      const result = getGGShieldUtils.getBundledGGShieldPath(platform, context);
+      assert.strictEqual(
+        result,
+        path.join("/ext", "ggshield-bundled", expectedBinary),
+      );
+    });
+  });
+});
+
+suite("getGGShieldVersion", () => {
+  test("reads version from ggshield_version file", () => {
+    const tempDir = fs.mkdtempSync(__dirname);
+    try {
+      fs.writeFileSync(path.join(tempDir, "ggshield_version"), "1.49.0\n");
+      const context = { extensionPath: tempDir } as ExtensionContext;
+      const version = getGGShieldUtils.getGGShieldVersion(context);
+      assert.strictEqual(version, "1.49.0");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+});
+
+function createFakeBundledBinary(
   tempDir: string,
   platform: NodeJS.Platform,
-  arch: string,
-  version: string,
 ): string {
-  const ggshieldFolder: string = path.join(tempDir, "ggshield-internal");
-  const binaryName: string = platform === "win32" ? "ggshield.exe" : "ggshield";
-  const versionFolder: string = path.join(
-    ggshieldFolder,
-    `${getGGShieldUtils.computeGGShieldFolderName(platform, arch, version)}`,
-  );
-  const binaryPath: string = path.join(versionFolder, binaryName);
-  fs.mkdirSync(versionFolder, { recursive: true });
+  const bundledDir = path.join(tempDir, "ggshield-bundled");
+  const binaryName = platform === "win32" ? "ggshield.exe" : "ggshield";
+  const binaryPath = path.join(bundledDir, binaryName);
+  fs.mkdirSync(bundledDir, { recursive: true });
   fs.writeFileSync(binaryPath, "fake binary content");
   return binaryPath;
 }
-
-suite("ggshield-resolver-utils", () => {
-  suite("computeGGShieldPath", () => {
-    const version = "1.0.0";
-    const ggshieldFolder = "/path/to/ggshield";
-
-    test("computes correct path for Windows", () => {
-      const result = getGGShieldUtils.computeGGShieldPath(
-        "win32",
-        "x64",
-        ggshieldFolder,
-        version,
-      );
-      assert.strictEqual(
-        result,
-        path.join(
-          ggshieldFolder,
-          "ggshield-1.0.0-x86_64-pc-windows-msvc",
-          "ggshield.exe",
-        ),
-      );
-    });
-    test("computes correct path for Windows arm64", () => {
-      const result = getGGShieldUtils.computeGGShieldPath(
-        "win32",
-        "arm64",
-        ggshieldFolder,
-        version,
-      );
-      assert.strictEqual(
-        result,
-        path.join(
-          ggshieldFolder,
-          "ggshield-1.0.0-x86_64-pc-windows-msvc",
-          "ggshield.exe",
-        ),
-      );
-    });
-
-    test("computes correct path for Linux", () => {
-      const result = getGGShieldUtils.computeGGShieldPath(
-        "linux",
-        "x64",
-        ggshieldFolder,
-        version,
-      );
-      assert.strictEqual(
-        result,
-        path.join(
-          ggshieldFolder,
-          "ggshield-1.0.0-x86_64-unknown-linux-gnu",
-          "ggshield",
-        ),
-      );
-    });
-
-    test("computes correct path for macOS x64", () => {
-      const result = getGGShieldUtils.computeGGShieldPath(
-        "darwin",
-        "x64",
-        ggshieldFolder,
-        version,
-      );
-      assert.strictEqual(
-        result,
-        path.join(
-          ggshieldFolder,
-          "ggshield-1.0.0-x86_64-apple-darwin",
-          "ggshield",
-        ),
-      );
-    });
-
-    test("computes correct path for macOS arm64", () => {
-      const result = getGGShieldUtils.computeGGShieldPath(
-        "darwin",
-        "arm64",
-        ggshieldFolder,
-        version,
-      );
-      assert.strictEqual(
-        result,
-        path.join(
-          ggshieldFolder,
-          "ggshield-1.0.0-arm64-apple-darwin",
-          "ggshield",
-        ),
-      );
-    });
-
-    test("throws error for unsupported platform", () => {
-      assert.throws(() => {
-        getGGShieldUtils.computeGGShieldPath(
-          "sunos",
-          "x64",
-          ggshieldFolder,
-          version,
-        );
-      }, /Unsupported platform/);
-    });
-
-    test("throws error for unsupported architecture", () => {
-      assert.throws(() => {
-        getGGShieldUtils.computeGGShieldPath(
-          "darwin",
-          "mips",
-          ggshieldFolder,
-          version,
-        );
-      }, /Unsupported architecture/);
-    });
-  });
-
-  suite("extractGGShieldBinary", () => {
-    const testContent = "hello world";
-    const testFileName = "test.txt";
-    let tempDir: string;
-    let tarGzPath: string;
-    let zipPath: string;
-
-    setup(() => {
-      // Create temporary directory
-      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ggshield-test-"));
-
-      // Create test file
-      const testFilePath = path.join(tempDir, testFileName);
-      fs.writeFileSync(testFilePath, testContent);
-
-      // Create tar.gz archive
-      tarGzPath = path.join(tempDir, "archive.tar.gz");
-      tar.create(
-        {
-          gzip: true,
-          file: tarGzPath,
-          cwd: tempDir,
-          sync: true,
-        },
-        [testFileName],
-      );
-
-      // Create zip archive
-      zipPath = path.join(tempDir, "archive.zip");
-      const zip = new AdmZip();
-      zip.addFile(testFileName, Buffer.from(testContent));
-      zip.writeZip(zipPath);
-    });
-
-    teardown(() => {
-      // Clean up temporary directory and its contents
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    });
-
-    test("extracts tar.gz files correctly", () => {
-      const extractDir = path.join(tempDir, "extract-tar");
-      fs.mkdirSync(extractDir);
-
-      getGGShieldUtils.extractGGShieldBinary(tarGzPath, extractDir);
-
-      const extractedContent = fs.readFileSync(
-        path.join(extractDir, testFileName),
-        "utf8",
-      );
-      assert.strictEqual(extractedContent, testContent);
-    });
-
-    test("extracts zip files correctly", () => {
-      const extractDir = path.join(tempDir, "extract-zip");
-      fs.mkdirSync(extractDir);
-
-      getGGShieldUtils.extractGGShieldBinary(zipPath, extractDir);
-
-      const extractedContent = fs.readFileSync(
-        path.join(extractDir, testFileName),
-        "utf8",
-      );
-      assert.strictEqual(extractedContent, testContent);
-    });
-
-    test("throws error for unsupported file extension", () => {
-      const rarPath = path.join(tempDir, "archive.rar");
-      fs.writeFileSync(rarPath, "unsupported file extension");
-
-      assert.throws(() => {
-        getGGShieldUtils.extractGGShieldBinary(rarPath, tempDir);
-      }, /Unsupported file extension/);
-    });
-  });
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,13 +53,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -80,13 +73,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
-
-"@types/adm-zip@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@types/adm-zip/-/adm-zip-0.5.7.tgz#eec10b6f717d3948beb64aca0abebc4b344ac7e9"
-  integrity sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==
-  dependencies:
-    "@types/node" "*"
 
 "@types/glob@^8.1.0":
   version "8.1.0"
@@ -132,14 +118,6 @@
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@types/simple-mock/-/simple-mock-0.8.6.tgz#cb87cf3147469705c73396339ef64bad597ced29"
   integrity sha512-tL1xxJhmUtKIX79TlasZF2OKoBXpQScxjrSBgqWZjdEEJXEKNR+SvT5HQNJ4hs+9pd/q5XLEluiZiyS6vSm7Hg==
-
-"@types/tar@^6.1.13":
-  version "6.1.13"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.13.tgz#9b5801c02175344101b4b91086ab2bbc8e93a9b6"
-  integrity sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==
-  dependencies:
-    "@types/node" "*"
-    minipass "^4.0.0"
 
 "@types/vscode@^1.81.0":
   version "1.94.0"
@@ -256,11 +234,6 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
   integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
 
-adm-zip@^0.5.16:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
-  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
-
 agent-base@^7.0.2, agent-base@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
@@ -317,20 +290,6 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
-axios@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
-  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -391,14 +350,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
-  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
-  dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -437,11 +388,6 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
-
 cli-cursor@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
@@ -474,13 +420,6 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -518,11 +457,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
 diff@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
@@ -542,15 +476,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dunder-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
-  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-errors "^1.3.0"
-    gopd "^1.2.0"
-
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -565,33 +490,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-es-define-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
-  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
-
-es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
-  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
-  dependencies:
-    es-errors "^1.3.0"
-
-es-set-tostringtag@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
-  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
-  dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
 
 escalade@^3.1.1:
   version "3.2.0"
@@ -780,22 +678,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.15.6:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
-
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -806,39 +688,10 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
-  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-intrinsic@^1.2.6:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
-  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.1.1"
-    function-bind "^1.1.2"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    math-intrinsics "^1.1.0"
-
-get-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
-  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
-  dependencies:
-    dunder-proto "^1.0.1"
-    es-object-atoms "^1.0.0"
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -896,11 +749,6 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-gopd@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
-  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
 graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
@@ -910,25 +758,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-has-symbols@^1.0.3, has-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
-  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
-
-has-tostringtag@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
-  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
-  dependencies:
-    has-symbols "^1.0.3"
-
-hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
-  dependencies:
-    function-bind "^1.1.2"
 
 he@^1.2.0:
   version "1.2.0"
@@ -1138,11 +967,6 @@ log-symbols@^5.1.0:
     chalk "^5.0.0"
     is-unicode-supported "^1.1.0"
 
-math-intrinsics@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
-  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -1155,18 +979,6 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
-
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -1186,28 +998,6 @@ minimatch@^5.0.1, minimatch@^5.1.6:
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
-
-minipass@^4.0.0:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
-  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
-
-minipass@^7.0.4, minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
-
-minizlib@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.0.2.tgz#f33d638eb279f664439aa38dc5f91607468cb574"
-  integrity sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==
-  dependencies:
-    minipass "^7.1.2"
-
-mkdirp@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
-  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
 mocha@^10.2.0:
   version "10.7.3"
@@ -1356,11 +1146,6 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -1571,18 +1356,6 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-tar@^7.4.3:
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.4.3.tgz#88bbe9286a3fcd900e94592cda7a22b192e80571"
-  integrity sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.0.1"
-    mkdirp "^3.0.1"
-    yallist "^5.0.0"
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -1676,11 +1449,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"


### PR DESCRIPTION
## Context

Currently, the extension downloads `ggshield` at runtime. This can cause issues in environments with no or restricted network access.

## What has been done

This PR replaces the runtime download with a build-time one. The `ggshield` binary is downloaded and bundled with the extension [in a platform-specific extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions). ~The PR also includes a configuration parameter `gitguardian.ggshieldPath` that allows to override the default of the bundled `ggshield`.~

#### Didn't we do this before?

We used to bundle `ggshield` in this extension until `e99b365`. This approach differs as follows:
 - binaries are not kept in the repo tree but downloaded at build-time from `ggshield` GitHub releases
 - we ship platform-specific extensions instead of a single extension containing binaries for all platforms

## Validation

1. Build and install the VSIX: `vsce package --target darwin-arm64 --allow-missing-repository && code
  --install-extension gitguardian-*.vsix`
2. Reload VS Code — verify the GitGuardian sidebar loads and scanning works

## PR check list

- [x] As much as possible, the changes include tests
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
