### PR TITLE
feat: add keyring config source

### DIFF
--- a/src/ggshield-webview/gitguardian-webview-view.ts
+++ b/src/ggshield-webview/gitguardian-webview-view.ts
@@ -188,7 +188,8 @@ export class GitGuardianWebviewProvider implements vscode.WebviewViewProvider {
           <p>Instance source: ${authenticationStatus.instanceSource}.</p>
           <p>API key source: ${authenticationStatus.keySource}.</p>
           ${
-            authenticationStatus.keySource === ConfigSource.keyGGShieldConfig
+            authenticationStatus.keySource === ConfigSource.keyGGShieldConfig ||
+            authenticationStatus.keySource === ConfigSource.keyring
               ? `
             <p>To generate a valid key, please <a id="logout" href="">log out</a> and log back in.</p>
             <script>

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -20,6 +20,7 @@ export enum GGShieldConfigSource {
   dotEnv = "DOTENV",
   envVar = "ENV_VAR",
   userConfig = "USER_CONFIG",
+  keyring = "KEYRING",
   default = "DEFAULT",
 }
 
@@ -29,6 +30,7 @@ export enum ConfigSource {
   envVar = "Environment variable",
   instanceGGShieldConfig = "ggshield settings or .gitguardian.yaml file",
   keyGGShieldConfig = "ggshield settings",
+  keyring = "System credential store",
   default = "Default instance",
   noKeyFound = "No key found",
 }
@@ -47,6 +49,8 @@ function getSource(sourceString: string, isInstance: boolean): ConfigSource {
       } else {
         return ConfigSource.keyGGShieldConfig;
       }
+    case GGShieldConfigSource.keyring:
+      return ConfigSource.keyring;
     case GGShieldConfigSource.default:
       return ConfigSource.default;
   }
@@ -172,7 +176,8 @@ export async function logoutGGShield(
     context.workspaceState.get("authenticationStatus");
   if (
     authStatus?.success === false &&
-    authStatus.keySource === ConfigSource.keyGGShieldConfig
+    (authStatus.keySource === ConfigSource.keyGGShieldConfig ||
+      authStatus.keySource === ConfigSource.keyring)
   ) {
     cmd.push("--no-revoke");
   }


### PR DESCRIPTION
## Context

[`ggshield` #1203](https://github.com/GitGuardian/ggshield/pull/1203) introduces OS credential stores as a configuration source.

## What has been done

Update the extension output for the added configuration source.
## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
