### PR TITLE
ci: disble gg scan run on dependabot and fork PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,10 @@ jobs:
   scanning:
     name: GitGuardian scan
     runs-on: ubuntu-latest
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Context

PRs from repo forks and dependabot do not have access to a gitguardian API token.

## What has been done

This commit adds a condition to the GitGuardian scan CI run, so that it only runs on PRs that are not authored by dependabot and do not come from a fork. 

## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
