### PR TITLE
docs: add links to detection engine documentation

### DIFF
--- a/src/ggshield-webview/gitguardian-webview-view.ts
+++ b/src/ggshield-webview/gitguardian-webview-view.ts
@@ -14,6 +14,12 @@ const feedbackFormUri = vscode.Uri.parse(
 const documentationUri = vscode.Uri.parse(
   "https://docs.gitguardian.com/ggshield-docs/configuration",
 );
+const engineFaqUri = vscode.Uri.parse(
+  "https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/frequently_asked_questions",
+);
+const enginePrecisionIntro = vscode.Uri.parse(
+  "https://blog.gitguardian.com/secrets-detection-accuracy-precision-recall-explained",
+);
 
 function escapeHtml(value: string): string {
   return value
@@ -116,6 +122,8 @@ export class GitGuardianWebviewProvider implements vscode.WebviewViewProvider {
           <p><a href="${projectDiscussionUri}" target="_blank">👉 Join the discussion: share feedback, ideas, and vote</a></p>
           <p><a href="${projectIssuesUri}" target="_blank">👉 Report any issues you encounter</a></p>
           <p><a href="${feedbackFormUri}" target="_blank">👉 Provide anonymous feedback</a></p>
+          <p><a href="${engineFaqUri}" target="_blank">👉 Read about our detection engine</a></p>
+          <p><a href="${enginePrecisionIntro}" target="_blank">👉 Find out how we choose what to report</a></p>
         </body>
         </html>`;
     } else if (


### PR DESCRIPTION
## Context

Users of the extension often test the extension by creating a file with a secret that the engine will treat as a false positive (e.g. `TEST_SECRET=abcdef123456`)

## What has been done

This PR adds documentation links to the [detection engine FAQ](https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/frequently_asked_questions) and [a blog post](https://blog.gitguardian.com/secrets-detection-accuracy-precision-recall-explained) explaining the engine's precision tradeoff.

## Validation

- If not already present, download the ggshield bundle by running `bash scripts/download-ggshield.sh --target $YOUR_OS_ARCH`
- Run the extension in debug mode in VSCode
- Ensure that the documentation links are displayed in the extension sidebar

## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
