### PR TITLE
6d7a/instance link

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "gitguardian-vscode",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
+  "runArgs": ["--platform=linux/amd64"],
+  "postCreateCommand": "yarn install --frozen-lockfile && bash scripts/download-ggshield.sh --target linux-x64 --force",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint"],
+      "settings": {
+        "gitguardian.apiUrl": "",
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "containerEnv": {
+    "HOME": "/home/node"
+  },
+  "remoteUser": "node"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.22.0]
 
+### Added
+
+- Quota view now shows the connected GitGuardian instance and exposes a title-bar action to open the instance URL setting. The view refreshes automatically when `gitguardian.apiUrl` changes.
+
 ### Changed
 
 - `ggshield` binaries are again bundled in the extension.

--- a/media/main.css
+++ b/media/main.css
@@ -31,4 +31,21 @@ button.large {
   cursor: pointer;
   border-radius: 5px;
   margin: 2em 0;
+  min-width: 18em;
+}
+
+button.secondary {
+  background-color: transparent;
+  color: inherit;
+  border: 1px solid currentColor;
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 5px;
+  margin: 0.5em 0 2em 0;
+  min-width: 18em;
+}
+
+.self-hosted-hint {
+  margin-bottom: 0;
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,12 @@
           "light": "images/refresh-light.svg",
           "dark": "images/refresh-dark.svg"
         }
+      },
+      {
+        "command": "gitguardian.openInstanceSettings",
+        "title": "Configure instance URL",
+        "category": "GitGuardian",
+        "icon": "$(link)"
       }
     ],
     "viewsContainers": {
@@ -150,7 +156,12 @@
       "view/title": [
         {
           "command": "gitguardian.refreshQuota",
-          "group": "navigation",
+          "group": "navigation@1",
+          "when": "view == gitguardianQuotaView"
+        },
+        {
+          "command": "gitguardian.openInstanceSettings",
+          "group": "navigation@2",
           "when": "view == gitguardianQuotaView"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,8 +114,31 @@ export async function activate(context: ExtensionContext) {
 
   //generic commands to open correct view on status bar click
   registerOpenViewsCommands(context, outputChannel);
-  commands.registerCommand("gitguardian.refreshQuota", () =>
-    ggshieldQuotaViewProvider.refresh(),
+  context.subscriptions.push(
+    commands.registerCommand("gitguardian.refreshQuota", () =>
+      ggshieldQuotaViewProvider.refresh(),
+    ),
+    commands.registerCommand("gitguardian.openInstanceSettings", () =>
+      commands.executeCommand(
+        "workbench.action.openSettings",
+        "gitguardian.apiUrl",
+      ),
+    ),
+  );
+
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(async (event) => {
+      if (!event.affectsConfiguration("gitguardian.apiUrl")) {
+        return;
+      }
+      configuration = getConfiguration(context, outputChannel);
+      ggshieldResolver.configuration = configuration;
+      ggshieldQuotaViewProvider.setConfiguration(configuration);
+      await updateAuthenticationStatus(context, configuration);
+      ggshieldViewProvider.refresh();
+      ggshieldRemediationMessageViewProvider.refresh();
+      ggshieldQuotaViewProvider.refresh();
+    }),
   );
 
   context.subscriptions.push(

--- a/src/ggshield-webview/gitguardian-quota-webview.ts
+++ b/src/ggshield-webview/gitguardian-quota-webview.ts
@@ -2,6 +2,7 @@ import { AuthenticationStatus } from "../lib/authentication";
 import { getAPIquota } from "../lib/ggshield-api";
 import * as vscode from "vscode";
 import { GGShieldConfiguration } from "../lib/ggshield-configuration";
+import { sanitizeInstanceUrl } from "./webview-utils";
 
 export class GitGuardianQuotaWebviewProvider
   implements vscode.WebviewViewProvider
@@ -11,6 +12,7 @@ export class GitGuardianQuotaWebviewProvider
   private quota: number = 0;
   private isLoading: boolean = false;
   private isAuthenticated: boolean = false;
+  private instance: string = "";
 
   constructor(
     private ggshieldConfiguration: GGShieldConfiguration,
@@ -34,13 +36,27 @@ export class GitGuardianQuotaWebviewProvider
     });
   }
 
+  public setConfiguration(configuration: GGShieldConfiguration) {
+    this.ggshieldConfiguration = configuration;
+  }
+
   private updateQuota() {
     const authStatus: AuthenticationStatus | undefined =
       this.context.workspaceState.get("authenticationStatus");
     this.isAuthenticated = authStatus?.success ?? false;
+    this.instance = authStatus?.instance ?? "";
     if (authStatus?.success) {
       this.quota = getAPIquota(this.ggshieldConfiguration);
+    } else {
+      this.quota = 0;
     }
+  }
+
+  private renderConnectedLine(): string {
+    const host = sanitizeInstanceUrl(this.instance).replace(/^https?:\/\//, "");
+    return host
+      ? `<p>Connected to: <strong>${host}</strong></p>`
+      : `<p><em>No instance configured.</em></p>`;
   }
 
   private updateWebViewContent() {
@@ -48,34 +64,24 @@ export class GitGuardianQuotaWebviewProvider
       return;
     }
 
-    let computedHtml: string;
+    const connectedLine = this.renderConnectedLine();
 
+    let body: string;
     if (this.isLoading) {
-      computedHtml = `
-        <!DOCTYPE html>
-        <html lang="en">
-        <body>
-          <p>Loading...</p>
-        </body>
-        </html>`;
+      body = `${connectedLine}<p>Loading...</p>`;
     } else if (this.quota !== 0 && this.isAuthenticated) {
-      computedHtml = `
-        <!DOCTYPE html>
-        <html lang="en">
-        <body>
-          <p>Your current quota: ${this.quota}</p>
-        </body>
-        </html>`;
+      body = `${connectedLine}<p>Your current quota: ${this.quota}</p>`;
     } else {
-      computedHtml = `
-        <!DOCTYPE html>
-        <html lang="en">
-        <body>
-            <p>Please authenticate to see your quota.</p>
-        </body>
-        </html>`;
+      body = `${connectedLine}<p>Please authenticate to see your quota.</p>`;
     }
-    this._view.webview.html = computedHtml;
+
+    this._view.webview.html = `
+      <!DOCTYPE html>
+      <html lang="en">
+      <body>
+        ${body}
+      </body>
+      </html>`;
   }
 
   public refresh() {

--- a/src/ggshield-webview/gitguardian-webview-view.ts
+++ b/src/ggshield-webview/gitguardian-webview-view.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 import { AuthenticationStatus, ConfigSource } from "../lib/authentication";
 import { GGShieldConfiguration } from "../lib/ggshield-configuration";
-import { sanitizeInstanceUrl } from "./webview-utils";
+import {
+  renderCurrentInstanceLine,
+  renderSelfHostedHint,
+  sanitizeInstanceUrl,
+} from "./webview-utils";
 
 const projectDiscussionUri = vscode.Uri.parse(
   "https://github.com/GitGuardian/gitguardian-vscode/discussions",
@@ -117,18 +121,25 @@ export class GitGuardianWebviewProvider implements vscode.WebviewViewProvider {
             <h1 style="margin-bottom:0px;">Welcome to GitGuardian</h1>
             <p>Protect your code from secrets leakage</p>
             <button class="button large" id="authenticate">Link your IDE to your account</button>
-            
+
             <p id="authMessage" style="display:none;">
               If your browser doesn't open automatically, <a id="authLink" href="#" target="_blank">click here</a>.
             </p>
+            ${renderSelfHostedHint()}
+            ${renderCurrentInstanceLine(authenticationStatus?.instance ?? "")}
           </div>
 
           <script>
             const vscode = acquireVsCodeApi();
-            
+
             // Button click event to trigger authentication
             document.getElementById('authenticate').addEventListener('click', () => {
               vscode.postMessage({ type: 'authenticate' });
+            });
+
+            document.getElementById('openInstanceSettings').addEventListener('click', (e) => {
+              e.preventDefault();
+              vscode.postMessage({ type: 'openInstanceSettings' });
             });
             
             // Listener for authentication link

--- a/src/ggshield-webview/gitguardian-webview-view.ts
+++ b/src/ggshield-webview/gitguardian-webview-view.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { AuthenticationStatus, ConfigSource } from "../lib/authentication";
 import { GGShieldConfiguration } from "../lib/ggshield-configuration";
+import { sanitizeInstanceUrl } from "./webview-utils";
 
 const projectDiscussionUri = vscode.Uri.parse(
   "https://github.com/GitGuardian/gitguardian-vscode/discussions",
@@ -14,27 +15,6 @@ const feedbackFormUri = vscode.Uri.parse(
 const documentationUri = vscode.Uri.parse(
   "https://docs.gitguardian.com/ggshield-docs/configuration",
 );
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
-
-function sanitizeInstanceUrl(instance: string): string {
-  try {
-    const url = new URL(instance);
-    if (url.protocol !== "https:" && url.protocol !== "http:") {
-      return "";
-    }
-    return escapeHtml(url.origin);
-  } catch {
-    return "";
-  }
-}
 
 export class GitGuardianWebviewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "gitguardian.gitguardianView";

--- a/src/ggshield-webview/webview-utils.ts
+++ b/src/ggshield-webview/webview-utils.ts
@@ -18,3 +18,15 @@ export function sanitizeInstanceUrl(instance: string): string {
     return "";
   }
 }
+
+export function renderSelfHostedHint(): string {
+  return `<p class="self-hosted-hint">Using a self-hosted instance?</p>
+          <button class="button secondary" id="openInstanceSettings">Configure instance URL</button>`;
+}
+
+export function renderCurrentInstanceLine(instance: string): string {
+  const sanitized = sanitizeInstanceUrl(instance);
+  return sanitized
+    ? `<p class="self-hosted-current">Connecting to <code>${sanitized}</code></p>`
+    : "";
+}

--- a/src/ggshield-webview/webview-utils.ts
+++ b/src/ggshield-webview/webview-utils.ts
@@ -1,0 +1,20 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+export function sanitizeInstanceUrl(instance: string): string {
+  try {
+    const url = new URL(instance);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return "";
+    }
+    return escapeHtml(url.origin);
+  } catch {
+    return "";
+  }
+}

--- a/src/test/suite/ggshield-webview/gitguardian-quota-webview.test.ts
+++ b/src/test/suite/ggshield-webview/gitguardian-quota-webview.test.ts
@@ -11,7 +11,6 @@ import {
 
 suite("GitGuardianQuotaWebviewProvider", () => {
   let provider: GitGuardianQuotaWebviewProvider;
-  let mockGGShieldConfig: Partial<GGShieldConfiguration>;
   let mockWebviewView: Partial<WebviewView>;
   let mockWorkspaceState: Memento & {
     setKeysForSync(keys: readonly string[]): void;
@@ -86,5 +85,51 @@ suite("GitGuardianQuotaWebviewProvider", () => {
         "<p>Please authenticate to see your quota.</p>",
       ),
     );
+  });
+
+  test("shows connected host above quota without scheme or in-body button", () => {
+    provider["isLoading"] = false;
+    provider["isAuthenticated"] = true;
+    provider["quota"] = 42;
+    provider["instance"] = "https://api.dashboard.example.com";
+
+    provider["updateWebViewContent"]();
+    const html = provider["_view"]?.webview.html ?? "";
+
+    assert.ok(
+      html.includes("Connected to: <strong>api.dashboard.example.com</strong>"),
+    );
+    assert.ok(!html.includes("https://api.dashboard.example.com"));
+    assert.ok(!html.includes("Instance source:"));
+    assert.ok(!html.includes("API key source:"));
+    assert.ok(!html.includes('id="openInstanceSettings"'));
+
+    const connectedIdx = html.indexOf("Connected to:");
+    const quotaIdx = html.indexOf("Your current quota:");
+    assert.ok(connectedIdx > -1 && quotaIdx > -1 && connectedIdx < quotaIdx);
+  });
+
+  test("shows placeholder when no instance is configured", () => {
+    provider["isLoading"] = false;
+    provider["isAuthenticated"] = false;
+    provider["instance"] = "";
+
+    provider["updateWebViewContent"]();
+    const html = provider["_view"]?.webview.html ?? "";
+
+    assert.ok(html.includes("No instance configured"));
+  });
+
+  test("sanitizes malformed instance URLs", () => {
+    provider["isLoading"] = false;
+    provider["isAuthenticated"] = true;
+    provider["quota"] = 1;
+    provider["instance"] = "javascript:alert(1)";
+
+    provider["updateWebViewContent"]();
+    const html = provider["_view"]?.webview.html ?? "";
+
+    assert.ok(!html.includes("javascript:alert"));
+    assert.ok(html.includes("No instance configured"));
   });
 });


### PR DESCRIPTION
## Context

Currently, the plugin is biased when it comes to a GitGuardian instance. For users of a self-hosted GitGuardian instance, the configuration of the extension is not self-explanatory.

## What has been done

- add a secondary button on the welcome view to guide self-hosting users
- add a icon button in the quota view for switching instances
- display the connected instance in the quota view
- add a devcontainer set-up for easier isolated testing

## PR check list

- [x] As much as possible, the changes include tests
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
