### PR TITLE
perf: do not block extension host while scanning

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import {
+  cancelInFlightScans,
   cleanUpFileDiagnostics,
   createDiagnosticCollection,
   ignoreLastFound,
@@ -150,7 +151,13 @@ export async function activate(context: ExtensionContext) {
     return;
   }
 
-  ggshieldResolver.checkGGShieldConfiguration();
+  ggshieldResolver.checkGGShieldConfiguration().catch((err) => {
+    outputChannel.appendLine(
+      `ggshield configuration check failed: ${
+        err instanceof Error ? err.stack ?? err.message : String(err)
+      }`,
+    );
+  });
 
   // update authentication status
   updateAuthenticationStatus(context, configuration).then(() => {
@@ -163,6 +170,7 @@ export async function activate(context: ExtensionContext) {
   // (i.e. when a new document is opened or when the document is saved)
   createDiagnosticCollection(context);
   context.subscriptions.push(
+    { dispose: cancelInFlightScans },
     workspace.onDidSaveTextDocument((textDocument) => {
       // Check if the document is inside the workspace
       const workspaceFolder = workspace.getWorkspaceFolder(textDocument.uri);
@@ -173,37 +181,54 @@ export async function activate(context: ExtensionContext) {
           textDocument.fileName,
           textDocument.uri,
           ggshieldResolver.configuration,
-        );
+        ).catch((err) => {
+          outputChannel.appendLine(
+            `scanFile failed: ${
+              err instanceof Error ? err.stack ?? err.message : String(err)
+            }`,
+          );
+        });
       }
     }),
     workspace.onDidCloseTextDocument((textDocument) =>
       cleanUpFileDiagnostics(textDocument.uri),
     ),
-    commands.registerCommand("gitguardian.quota", () => {
-      showAPIQuota(ggshieldResolver.configuration);
+    commands.registerCommand("gitguardian.quota", async () => {
+      try {
+        await showAPIQuota(ggshieldResolver.configuration);
+      } catch (err) {
+        outputChannel.appendLine(
+          `showAPIQuota failed: ${
+            err instanceof Error ? err.stack ?? err.message : String(err)
+          }`,
+        );
+      }
     }),
-    commands.registerCommand("gitguardian.ignore", () => {
-      ignoreLastFound(ggshieldResolver.configuration);
+    commands.registerCommand("gitguardian.ignore", async () => {
+      await ignoreLastFound(ggshieldResolver.configuration);
       if (window.activeTextEditor) {
         cleanUpFileDiagnostics(window.activeTextEditor?.document.uri);
       }
     }),
-    commands.registerCommand("gitguardian.ignoreSecret", (diagnosticData) => {
-      window.showInformationMessage("Secret ignored.");
-      let currentFile = getCurrentFile();
-      let secretName = generateSecretName(currentFile, diagnosticData);
+    commands.registerCommand(
+      "gitguardian.ignoreSecret",
+      async (diagnosticData) => {
+        window.showInformationMessage("Secret ignored.");
+        let currentFile = getCurrentFile();
+        let secretName = generateSecretName(currentFile, diagnosticData);
 
-      ignoreSecret(
-        ggshieldResolver.configuration,
-        diagnosticData.secretSha,
-        secretName,
-      );
-      scanFile(
-        currentFile,
-        Uri.file(currentFile),
-        ggshieldResolver.configuration,
-      );
-    }),
+        await ignoreSecret(
+          ggshieldResolver.configuration,
+          diagnosticData.secretSha,
+          secretName,
+        );
+        await scanFile(
+          currentFile,
+          Uri.file(currentFile),
+          ggshieldResolver.configuration,
+        );
+      },
+    ),
     commands.registerCommand("gitguardian.authenticate", async () => {
       commands.executeCommand("gitguardian.openSidebar");
       await loginGGShield(

--- a/src/ggshield-webview/gitguardian-quota-webview.ts
+++ b/src/ggshield-webview/gitguardian-quota-webview.ts
@@ -26,12 +26,16 @@ export class GitGuardianQuotaWebviewProvider
     _token: vscode.CancellationToken,
   ) {
     this._view = webviewView;
-    this.refresh();
+    void this.refresh().catch((err) => {
+      console.error("GitGuardian quota refresh failed:", err);
+    });
 
     webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible) {
         // Refresh the quota when the view becomes visible (e.g., after being collapsed and reopened)
-        this.refresh();
+        void this.refresh().catch((err) => {
+          console.error("GitGuardian quota refresh failed:", err);
+        });
       }
     });
   }
@@ -40,13 +44,13 @@ export class GitGuardianQuotaWebviewProvider
     this.ggshieldConfiguration = configuration;
   }
 
-  private updateQuota() {
+  private async updateQuota(): Promise<void> {
     const authStatus: AuthenticationStatus | undefined =
       this.context.workspaceState.get("authenticationStatus");
     this.isAuthenticated = authStatus?.success ?? false;
     this.instance = authStatus?.instance ?? "";
     if (authStatus?.success) {
-      this.quota = getAPIquota(this.ggshieldConfiguration);
+      this.quota = await getAPIquota(this.ggshieldConfiguration);
     } else {
       this.quota = 0;
     }
@@ -84,11 +88,11 @@ export class GitGuardianQuotaWebviewProvider
       </html>`;
   }
 
-  public refresh() {
+  public async refresh(): Promise<void> {
     this.isLoading = true;
     this.updateWebViewContent();
 
-    this.updateQuota();
+    await this.updateQuota();
 
     this.isLoading = false;
     this.updateWebViewContent();

--- a/src/lib/authentication.ts
+++ b/src/lib/authentication.ts
@@ -66,7 +66,10 @@ export async function updateAuthenticationStatus(
   context: ExtensionContext,
   configuration: GGShieldConfiguration,
 ): Promise<void> {
-  const proc = runGGShieldCommand(configuration, ["api-status", "--json"]);
+  const proc = await runGGShieldCommand(configuration, [
+    "api-status",
+    "--json",
+  ]);
 
   let authStatus: AuthenticationStatus;
   if (proc.stderr.includes("No token is saved for this instance")) {
@@ -181,6 +184,6 @@ export async function logoutGGShield(
   ) {
     cmd.push("--no-revoke");
   }
-  runGGShieldCommand(configuration, cmd);
+  await runGGShieldCommand(configuration, cmd);
   await updateAuthenticationStatus(context, configuration);
 }

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -21,18 +21,31 @@ import { parseGGShieldResults } from "./ggshield-results-parser";
  */
 export let diagnosticCollection: DiagnosticCollection;
 
+// Tracks the in-flight scan per URI so a later save can abort an earlier one
+// and we can drop stale results that return after being superseded.
+const inFlightScans = new Map<string, AbortController>();
+
+export function cancelInFlightScans(): void {
+  for (const controller of inFlightScans.values()) {
+    controller.abort();
+  }
+  inFlightScans.clear();
+}
+
 /**
  * Display API quota
  *
  * Show error message on failure
  */
-export function showAPIQuota(configuration: GGShieldConfiguration): undefined {
+export async function showAPIQuota(
+  configuration: GGShieldConfiguration,
+): Promise<void> {
   if (!configuration) {
     window.showErrorMessage("ggshield: Missing settings");
     return;
   }
 
-  const proc = runGGShieldCommand(configuration, ["quota"]);
+  const proc = await runGGShieldCommand(configuration, ["quota"]);
 
   if (proc.stderr.length > 0) {
     window.showErrorMessage(`ggshield: ${proc.stderr}`);
@@ -42,9 +55,11 @@ export function showAPIQuota(configuration: GGShieldConfiguration): undefined {
   }
 }
 
-export function getAPIquota(configuration: GGShieldConfiguration): number {
+export async function getAPIquota(
+  configuration: GGShieldConfiguration,
+): Promise<number> {
   try {
-    const proc = runGGShieldCommand(configuration, ["quota", "--json"]);
+    const proc = await runGGShieldCommand(configuration, ["quota", "--json"]);
     return JSON.parse(proc.stdout).remaining;
   } catch (e) {
     return 0;
@@ -56,15 +71,15 @@ export function getAPIquota(configuration: GGShieldConfiguration): number {
  *
  * Show error message on failure
  */
-export function ignoreLastFound(
+export async function ignoreLastFound(
   configuration: GGShieldConfiguration,
-): undefined {
+): Promise<void> {
   if (!configuration) {
     window.showErrorMessage("ggshield: Missing settings");
     return;
   }
 
-  const proc = runGGShieldCommand(configuration, [
+  const proc = await runGGShieldCommand(configuration, [
     "secret",
     "ignore",
     "--last-found",
@@ -83,12 +98,12 @@ export function ignoreLastFound(
  *
  * Show error message on failure
  */
-export function ignoreSecret(
+export async function ignoreSecret(
   configuration: GGShieldConfiguration,
   secretSha: string,
   secretName: string,
-): boolean {
-  const proc = runGGShieldCommand(configuration, [
+): Promise<boolean> {
+  const proc = await runGGShieldCommand(configuration, [
     "secret",
     "ignore",
     secretSha,
@@ -129,22 +144,37 @@ export function cleanUpFileDiagnostics(fileUri: Uri): void {
  * @param filePath path to file
  * @param fileUri file uri
  */
-export function scanFile(
+export async function scanFile(
   filePath: string,
   fileUri: Uri,
   configuration: GGShieldConfiguration,
-): void {
+): Promise<void> {
   if (isFileGitignored(filePath)) {
     updateStatusBarItem(StatusBarStatus.ignoredFile);
     return;
   }
-  const proc = runGGShieldCommand(configuration, [
-    "secret",
-    "scan",
-    "--json",
-    "path",
-    filePath,
-  ]);
+
+  const key = fileUri.toString();
+  inFlightScans.get(key)?.abort();
+  const controller = new AbortController();
+  inFlightScans.set(key, controller);
+
+  const proc = await runGGShieldCommand(
+    configuration,
+    ["secret", "scan", "--json", "path", filePath],
+    controller.signal,
+  );
+
+  // Superseded by a newer scan for this URI — drop the result.
+  if (inFlightScans.get(key) !== controller) {
+    return;
+  }
+  inFlightScans.delete(key);
+
+  // Aborted or failed to spawn — no meaningful exit status to interpret.
+  if (controller.signal.aborted || proc.status === null) {
+    return;
+  }
 
   if (proc.status === 128 || proc.status === 3) {
     const errorMessage = proc.stderr

--- a/src/lib/ggshield-resolver.ts
+++ b/src/lib/ggshield-resolver.ts
@@ -27,9 +27,9 @@ export class GGShieldResolver {
    *
    * @returns {void} A promise that resolves once the `ggshield` path is determined.
    */
-  checkGGShieldConfiguration(): void {
+  async checkGGShieldConfiguration(): Promise<void> {
     try {
-      this.testConfiguration(this.configuration);
+      await this.testConfiguration(this.configuration);
       return;
     } catch (error) {
       const errorMessage =
@@ -43,11 +43,11 @@ export class GGShieldResolver {
   /**
    * Tries the configuration from settings.
    *
-   * @returns {void} A promise that resolves if the configuration is valid.
+   * @returns {Promise<void>} A promise that resolves if the configuration is valid.
    */
-  testConfiguration(configuration: GGShieldConfiguration): void {
+  async testConfiguration(configuration: GGShieldConfiguration): Promise<void> {
     // Check if the ggshield path is valid
-    let proc = runGGShieldCommand(configuration, ["--version"]);
+    let proc = await runGGShieldCommand(configuration, ["--version"]);
     if (proc.status !== 0) {
       window.showErrorMessage(
         `GitGuardian: Invalid ggshield path. ${proc.stderr}`,

--- a/src/lib/run-ggshield.ts
+++ b/src/lib/run-ggshield.ts
@@ -1,65 +1,138 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {
-  spawnSync,
-  SpawnSyncOptionsWithStringEncoding,
-  SpawnSyncReturns,
-} from "child_process";
+import { spawn, SpawnOptionsWithoutStdio } from "child_process";
 import { GGShieldConfiguration } from "./ggshield-configuration";
 import { workspace } from "vscode";
 
 import * as os from "os";
+
+export interface GGShieldCommandResult {
+  pid: number;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
 /**
- * Run ggshield CLI application with specified arguments
+ * Run ggshield CLI application with specified arguments.
+ *
+ * Runs asynchronously so it does not block the VS Code extension host. The
+ * returned promise always resolves — process failures surface via the `error`
+ * field and/or a non-zero `status`, matching the shape previously returned by
+ * `spawnSync`.
  *
  * @param configuration ggshield configuration
  * @param args arguments
- * @returns
+ * @param signal optional AbortSignal to cancel an in-flight invocation
  */
 export function runGGShieldCommand(
   configuration: GGShieldConfiguration,
   args: string[],
-): SpawnSyncReturns<string> {
-  let env: NodeJS.ProcessEnv = {
+  signal?: AbortSignal,
+): Promise<GGShieldCommandResult> {
+  if (!workspace.isTrusted) {
+    const errorMessage =
+      "GitGuardian: cannot run ggshield in an untrusted workspace.";
+    return Promise.resolve({
+      pid: -1,
+      status: 3,
+      signal: null,
+      stdout: "",
+      stderr: errorMessage,
+      error: new Error(errorMessage),
+    });
+  }
+
+  let finalArgs = args.slice();
+  if (configuration.insecure) {
+    finalArgs = ["--insecure"].concat(finalArgs);
+  }
+  if (configuration.apiUrl && !finalArgs.includes("--version")) {
+    finalArgs.push("--instance", configuration.apiUrl);
+  }
+
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     GG_USER_AGENT: "gitguardian-vscode",
   };
 
-  let options: SpawnSyncOptionsWithStringEncoding = {
-    cwd: workspace.workspaceFolders
-      ? workspace.workspaceFolders[0].uri.fsPath
-      : os.tmpdir(),
-    env: env,
-    encoding: "utf-8",
+  // If the command is executed in a workspace, execute ggshield from the root
+  // folder so .gitguardian.yaml is used.
+  const cwd = workspace.workspaceFolders?.length
+    ? workspace.workspaceFolders[0].uri.fsPath
+    : os.tmpdir();
+
+  const options: SpawnOptionsWithoutStdio = {
+    cwd,
+    env,
     windowsHide: true,
+    signal,
   };
 
-  // If the command is executed in a worskpace, execute ggshield from the root folder so .gitguardian.yaml is used
-  if (workspace.workspaceFolders?.length || 0 > 0) {
-    options["cwd"] = workspace.workspaceFolders![0].uri.fsPath;
-  }
-  if (configuration.insecure) {
-    args = ["--insecure"].concat(args);
-  }
+  return new Promise<GGShieldCommandResult>((resolve) => {
+    let proc;
+    try {
+      proc = spawn(configuration.ggshieldPath, finalArgs, options);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      resolve({
+        pid: -1,
+        status: null,
+        signal: null,
+        stdout: "",
+        stderr: error.message,
+        error,
+      });
+      return;
+    }
 
-  if (configuration.apiUrl && !args.includes("--version")) {
-    args.push("--instance", configuration.apiUrl);
-  }
-
-  if (!workspace.isTrusted) {
-    const errorMessage =
-      "GitGuardian: cannot run ggshield in an untrusted workspace.";
-    return {
-      pid: -1,
-      status: 3,
-      signal: null,
-      output: ["", "", errorMessage],
-      stdout: "",
-      stderr: errorMessage,
-      error: new Error(errorMessage),
+    let stdout = "";
+    let stderr = "";
+    let spawnError: Error | undefined;
+    let settled = false;
+    const settle = (result: GGShieldCommandResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
     };
-  }
 
-  let proc = spawnSync(configuration.ggshieldPath, args, options);
+    proc.stdout?.setEncoding("utf-8");
+    proc.stderr?.setEncoding("utf-8");
+    proc.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    proc.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
 
-  return proc;
+    proc.on("error", (err) => {
+      spawnError = err;
+      // If the child never actually spawned (e.g. ENOENT, aborted signal),
+      // 'close' may not fire — resolve here so callers never hang.
+      if (!proc.pid) {
+        settle({
+          pid: -1,
+          status: null,
+          signal: null,
+          stdout,
+          stderr: stderr || err.message,
+          error: err,
+        });
+      }
+    });
+
+    proc.on("close", (status, sig) => {
+      settle({
+        pid: proc.pid ?? -1,
+        status,
+        signal: sig,
+        stdout,
+        stderr,
+        error: spawnError,
+      });
+    });
+  });
 }

--- a/src/test/suite/lib/authentication.test.ts
+++ b/src/test/suite/lib/authentication.test.ts
@@ -51,12 +51,14 @@ suite("updateAuthenticationStatus", () => {
   });
 
   test("returns noKeyFound status when no key is configured", async () => {
-    runGGShieldMock.returnWith({
-      status: 3,
-      stdout: "",
-      stderr:
-        "Error: No token is saved for this instance: 'https://dashboard.gitguardian.com'",
-    });
+    runGGShieldMock.returnWith(
+      Promise.resolve({
+        status: 3,
+        stdout: "",
+        stderr:
+          "Error: No token is saved for this instance: 'https://dashboard.gitguardian.com'",
+      }),
+    );
 
     await updateAuthenticationStatus(
       mockContext as ExtensionContext,
@@ -84,16 +86,18 @@ suite("updateAuthenticationStatus", () => {
   });
 
   test("returns true when valid credentials are configured", async () => {
-    runGGShieldMock.returnWith({
-      status: 0,
-      stdout: `{
-          "status_code": 200, 
+    runGGShieldMock.returnWith(
+      Promise.resolve({
+        status: 0,
+        stdout: `{
+          "status_code": 200,
           "instance": "https://dashboard.gitguardian.com",
           "api_key_source": "${GGShieldConfigSource.userConfig}",
           "instance_source": "${GGShieldConfigSource.userConfig}"
         }`,
-      stderr: "",
-    });
+        stderr: "",
+      }),
+    );
 
     await updateAuthenticationStatus(
       mockContext as ExtensionContext,
@@ -122,16 +126,18 @@ suite("updateAuthenticationStatus", () => {
   });
 
   test("returns false with correct sources and instance when API key is invalid", async () => {
-    runGGShieldMock.returnWith({
-      status: 0,
-      stdout: `{
-        "status_code": 401, 
+    runGGShieldMock.returnWith(
+      Promise.resolve({
+        status: 0,
+        stdout: `{
+        "status_code": 401,
         "instance": "https://dashboard.gitguardian.com",
         "api_key_source": "${GGShieldConfigSource.dotEnv}",
         "instance_source": "${GGShieldConfigSource.cmdOption}"
       }`,
-      stderr: "",
-    });
+        stderr: "",
+      }),
+    );
 
     await updateAuthenticationStatus(
       mockContext as ExtensionContext,

--- a/src/test/suite/lib/ggshield-api.test.ts
+++ b/src/test/suite/lib/ggshield-api.test.ts
@@ -27,36 +27,36 @@ suite("scanFile", () => {
     simple.restore();
   });
 
-  test("successfully scans a file with no incidents", () => {
-    runGGShieldCommandMock.returnWith({
-      status: 0,
-      stdout: scanResultsNoIncident,
-      stderr: "",
-    });
+  test("successfully scans a file with no incidents", async () => {
+    runGGShieldCommandMock.returnWith(
+      Promise.resolve({
+        status: 0,
+        stdout: scanResultsNoIncident,
+        stderr: "",
+      }),
+    );
 
     const testFile: string = path.join("test", "test.py");
-    scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
+    await scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
 
-    // The status bar displays "No Secret Found"
-    assert.strictEqual(updateStatusBarMock.callCount, 1);
     assert.strictEqual(
       updateStatusBarMock.lastCall.args[0],
       statusBar.StatusBarStatus.noSecretFound,
     );
   });
 
-  test("successfully scans a file with incidents", () => {
-    runGGShieldCommandMock.returnWith({
-      status: 1,
-      stdout: scanResultsWithIncident,
-      stderr: "",
-    });
+  test("successfully scans a file with incidents", async () => {
+    runGGShieldCommandMock.returnWith(
+      Promise.resolve({
+        status: 1,
+        stdout: scanResultsWithIncident,
+        stderr: "",
+      }),
+    );
 
     const testFile: string = path.join("test", "test.py");
-    scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
+    await scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
 
-    // The status bar displays "Secret Found"
-    assert.strictEqual(updateStatusBarMock.callCount, 1);
     assert.strictEqual(
       updateStatusBarMock.lastCall.args[0],
       statusBar.StatusBarStatus.secretFound,
@@ -66,12 +66,12 @@ suite("scanFile", () => {
     assert.strictEqual(diagnosticCollection.get(Uri.file(testFile))?.length, 1);
   });
 
-  test("skips the file if it is gitignored", () => {
+  test("skips the file if it is gitignored", async () => {
     // Mock isFileGitignored to return true
     simple.mock(utils, "isFileGitignored").returnWith(true);
 
     const filePath = path.join("out", "test.py");
-    scanFile(filePath, Uri.file(filePath), {} as GGShieldConfiguration);
+    await scanFile(filePath, Uri.file(filePath), {} as GGShieldConfiguration);
 
     // Verify that runGGShieldCommand was never called
     assert.strictEqual(runGGShieldCommandMock.callCount, 0);
@@ -86,15 +86,17 @@ suite("scanFile", () => {
 
   const errorCodes = [128, 3];
   errorCodes.forEach((code) => {
-    test(`displays an error message if the scan command fails with error code ${code}`, () => {
-      runGGShieldCommandMock.returnWith({
-        status: code,
-        stdout: "",
-        stderr: "Error",
-      });
+    test(`displays an error message if the scan command fails with error code ${code}`, async () => {
+      runGGShieldCommandMock.returnWith(
+        Promise.resolve({
+          status: code,
+          stdout: "",
+          stderr: "Error",
+        }),
+      );
 
       const testFile: string = path.join("test", "test.py");
-      scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
+      await scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
 
       // The error message is displayed
       assert.strictEqual(errorMessageMock.callCount, 1);
@@ -102,20 +104,65 @@ suite("scanFile", () => {
     });
   });
 
-  test("ignores the 'ignored file cannot be scanned' error", () => {
-    runGGShieldCommandMock.returnWith({
-      status: 2,
-      stdout: "",
-      stderr: "Error: An ignored file or directory cannot be scanned.",
+  test("drops results from a scan that was superseded for the same URI", async () => {
+    // Queue two resolvers so we can control completion order independently.
+    const resolvers: Array<
+      (value: { status: number; stdout: string; stderr: string }) => void
+    > = [];
+    runGGShieldCommandMock.callFn(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const testFile: string = path.join("test", "supersede.py");
+    const uri = Uri.file(testFile);
+
+    const first = scanFile(testFile, uri, {} as GGShieldConfiguration);
+    const second = scanFile(testFile, uri, {} as GGShieldConfiguration);
+
+    // Resolve the superseded (first) scan with incident data that would
+    // otherwise write diagnostics and flip the status bar.
+    resolvers[0]({
+      status: 1,
+      stdout: scanResultsWithIncident,
+      stderr: "",
     });
+    await first;
+
+    // Then resolve the winning (second) scan with no-incident data.
+    resolvers[1]({
+      status: 0,
+      stdout: scanResultsNoIncident,
+      stderr: "",
+    });
+    await second;
+
+    // Only the second scan's status bar update should have landed.
+    assert.strictEqual(updateStatusBarMock.callCount, 1);
+    assert.strictEqual(
+      updateStatusBarMock.lastCall.args[0],
+      statusBar.StatusBarStatus.noSecretFound,
+    );
+    // And the stale scan must not have written its incident diagnostics.
+    assert.strictEqual(diagnosticCollection.get(uri)?.length ?? 0, 0);
+  });
+
+  test("ignores the 'ignored file cannot be scanned' error", async () => {
+    runGGShieldCommandMock.returnWith(
+      Promise.resolve({
+        status: 2,
+        stdout: "",
+        stderr: "Error: An ignored file or directory cannot be scanned.",
+      }),
+    );
 
     const testFile: string = path.join("test", "test");
-    scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
+    await scanFile(testFile, Uri.file(testFile), {} as GGShieldConfiguration);
 
     // No error message is displayed
     assert.strictEqual(errorMessageMock.callCount, 0);
-    // The status bar displays "Ignored File"
-    assert.strictEqual(updateStatusBarMock.callCount, 1);
     assert.strictEqual(
       updateStatusBarMock.lastCall.args[0],
       statusBar.StatusBarStatus.ignoredFile,

--- a/src/test/suite/lib/run-ggshield.test.ts
+++ b/src/test/suite/lib/run-ggshield.test.ts
@@ -3,35 +3,61 @@ import * as childProcess from "child_process";
 import * as vscode from "vscode";
 import * as runGGShield from "../../../lib/run-ggshield";
 import assert = require("assert");
+import { EventEmitter } from "events";
 import { GGShieldConfiguration } from "../../../lib/ggshield-configuration";
 
+type FakeProc = EventEmitter & {
+  stdout: EventEmitter & { setEncoding: (enc: string) => void };
+  stderr: EventEmitter & { setEncoding: (enc: string) => void };
+  pid: number;
+};
+
+function makeFakeProc(): FakeProc {
+  const stdout = Object.assign(new EventEmitter(), {
+    setEncoding: () => {},
+  });
+  const stderr = Object.assign(new EventEmitter(), {
+    setEncoding: () => {},
+  });
+  return Object.assign(new EventEmitter(), { stdout, stderr, pid: 1234 });
+}
+
 suite("runGGShieldCommand", () => {
-  let spawnSyncMock: simple.Stub<Function>;
+  let spawnMock: simple.Stub<any>;
+  let fakeProc: FakeProc;
 
   setup(() => {
-    spawnSyncMock = simple.mock(childProcess, "spawnSync"); // Mock spawnSync
+    fakeProc = makeFakeProc();
+    spawnMock = simple.mock(childProcess, "spawn").returnWith(fakeProc);
   });
 
   teardown(() => {
     simple.restore();
   });
 
-  test("Global env variables are set correctly", () => {
+  // Helper: drive the fake process to completion after the runGGShieldCommand
+  // call has attached its listeners.
+  function finishProc(status: number = 0) {
+    // Defer so the promise has a chance to wire up handlers before close fires.
+    setImmediate(() => fakeProc.emit("close", status, null));
+  }
+
+  test("Global env variables are set correctly", async () => {
     process.env.TEST_GLOBAL_VAR = "GlobalValue";
-    runGGShield.runGGShieldCommand(
+    const resultPromise = runGGShield.runGGShieldCommand(
       {
         ggshieldPath: "path/to/ggshield",
         apiUrl: "",
       } as GGShieldConfiguration,
       [],
     );
+    finishProc();
+    await resultPromise;
 
-    // Assert that spawnSync was called
-    assert(spawnSyncMock.called, "spawnSync should be called once");
+    assert(spawnMock.called, "spawn should be called once");
 
-    // Check the arguments passed to spawnSync
-    const spawnSyncArgs = spawnSyncMock.lastCall.args;
-    const options = spawnSyncArgs[2];
+    const spawnArgs = spawnMock.lastCall.args;
+    const options = spawnArgs[2];
     assert.strictEqual(options.env.TEST_GLOBAL_VAR, "GlobalValue");
 
     delete process.env.TEST_GLOBAL_VAR;
@@ -51,10 +77,10 @@ suite("runGGShieldCommand", () => {
   ];
 
   testCasesInsecure.forEach(({ insecure: insecure, description }) => {
-    test(description, () => {
+    test(description, async () => {
       process.env.TEST_GLOBAL_VAR = "GlobalValue";
 
-      runGGShield.runGGShieldCommand(
+      const resultPromise = runGGShield.runGGShieldCommand(
         {
           ggshieldPath: "path/to/ggshield",
           apiUrl: "",
@@ -62,49 +88,55 @@ suite("runGGShieldCommand", () => {
         } as GGShieldConfiguration,
         ["test"],
       );
+      finishProc();
+      await resultPromise;
 
-      assert(spawnSyncMock.called, "spawnSync should be called once");
+      assert(spawnMock.called, "spawn should be called once");
 
-      const spawnSyncArgs = spawnSyncMock.lastCall.args;
-      const args = spawnSyncArgs[1];
+      const spawnArgs = spawnMock.lastCall.args;
+      const args = spawnArgs[1];
 
       assert.strictEqual(args[0] === "--insecure", insecure);
     });
   });
 
-  test("adds the --instance option when apiUrl is set in the settings", () => {
-    runGGShield.runGGShieldCommand(
+  test("adds the --instance option when apiUrl is set in the settings", async () => {
+    const resultPromise = runGGShield.runGGShieldCommand(
       {
         ggshieldPath: "path/to/ggshield",
         apiUrl: "https://example.com",
       } as GGShieldConfiguration,
       ["test"],
     );
+    finishProc();
+    await resultPromise;
 
-    assert(spawnSyncMock.called, "spawnSync should be called once");
+    assert(spawnMock.called, "spawn should be called once");
 
-    assert.deepStrictEqual(spawnSyncMock.lastCall.args[1], [
+    assert.deepStrictEqual(spawnMock.lastCall.args[1], [
       "test",
       "--instance",
       "https://example.com",
     ]);
   });
 
-  test("does not add the --instance option when calling ggshield --version", () => {
-    runGGShield.runGGShieldCommand(
+  test("does not add the --instance option when calling ggshield --version", async () => {
+    const resultPromise = runGGShield.runGGShieldCommand(
       {
         ggshieldPath: "path/to/ggshield",
         apiUrl: "https://example.com",
       } as GGShieldConfiguration,
       ["--version"],
     );
+    finishProc();
+    await resultPromise;
 
-    assert(spawnSyncMock.called, "spawnSync should be called once");
+    assert(spawnMock.called, "spawn should be called once");
 
-    assert.deepStrictEqual(spawnSyncMock.lastCall.args[1], ["--version"]);
+    assert.deepStrictEqual(spawnMock.lastCall.args[1], ["--version"]);
   });
 
-  test("returns a failed result without spawning ggshield in an untrusted workspace", () => {
+  test("returns a failed result without spawning ggshield in an untrusted workspace", async () => {
     const originalDescriptor = Object.getOwnPropertyDescriptor(
       vscode.workspace,
       "isTrusted",
@@ -115,7 +147,7 @@ suite("runGGShieldCommand", () => {
     });
 
     try {
-      const result = runGGShield.runGGShieldCommand(
+      const result = await runGGShield.runGGShieldCommand(
         {
           ggshieldPath: "path/to/ggshield",
           apiUrl: "",
@@ -123,7 +155,7 @@ suite("runGGShieldCommand", () => {
         ["secret", "scan", "--json", "test.py"],
       );
 
-      assert(!spawnSyncMock.called, "spawnSync should not be called");
+      assert(!spawnMock.called, "spawn should not be called");
       assert.strictEqual(result.status, 3);
       assert.strictEqual(result.pid, -1);
       assert.ok(


### PR DESCRIPTION
## Context

Currently, the extension synchronously spawns a `ggshield` process, blocking the extension host in the process. In poor network conditions, this could block other extensions from running for several seconds. 

## What has been done

This commit refactors the `ggshield` call, so that it is invoked asynchronously.

## Validation

- build an run the extension
- open a project, add a secret to a file and make sure it is detected as before

## PR check list

- [x] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
