### PR TITLE
refactor: show finding in problems panel on single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `ggshield` binaries are again bundled in the extension.
 - Distribute platform-specific extensions to limit the extension size with bundled `ggshield`.
+- Findings now appear as single-line entries in the Problems panel. Full incident details (validity, dashboard status, occurrences, incident URL, SHA, vault info) are shown on hover instead of inline.
 
 ## [0.21.0]
 

--- a/src/gitguardian-interface/gitguardian-hover-provider.ts
+++ b/src/gitguardian-interface/gitguardian-hover-provider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { GitGuardianDiagnostic } from "../lib/ggshield-results-parser";
 
 export class GitGuardianSecretHoverProvider implements vscode.HoverProvider {
   public provideHover(
@@ -13,10 +14,15 @@ export class GitGuardianSecretHoverProvider implements vscode.HoverProvider {
         diagnostic.range.contains(position) &&
         diagnostic.source === "gitguardian"
       ) {
+        const ggDiagnostic = diagnostic as GitGuardianDiagnostic;
         const hoverMessage = new vscode.MarkdownString();
         hoverMessage.isTrusted = true;
 
-        const diagnosticData = diagnosticToJSON(diagnostic);
+        if (ggDiagnostic.details) {
+          hoverMessage.appendCodeblock(ggDiagnostic.details, "text");
+        }
+
+        const diagnosticData = diagnosticToJSON(ggDiagnostic);
         const encodedDiagnosticData = encodeURIComponent(diagnosticData);
 
         hoverMessage.appendMarkdown(
@@ -30,37 +36,14 @@ export class GitGuardianSecretHoverProvider implements vscode.HoverProvider {
   }
 }
 
-function diagnosticToJSON(diagnostic: vscode.Diagnostic) {
-  // Extract the infos useful to generate the secret name
-  const { detector, secretSha } = extractInfosFromMessage(diagnostic.message);
-
+function diagnosticToJSON(diagnostic: GitGuardianDiagnostic) {
   const diagnosticObject = {
     startLine: diagnostic.range.start.line,
-    detector: detector,
-    secretSha: secretSha,
+    detector: diagnostic.detector,
+    secretSha: diagnostic.secretSha,
   };
 
-  // Convert the object to a JSON string
   return JSON.stringify(diagnosticObject);
-}
-
-function extractInfosFromMessage(message: string): {
-  detector: string;
-  secretSha: string;
-} {
-  const regexDetectorPattern = /Secret detected: ([a-zA-Z ]+)/;
-  const regexShaPattern = /Secret SHA: ([a-zA-Z0-9]+)/;
-
-  const matchDetector = message.match(regexDetectorPattern);
-  const matchSha = message.match(regexShaPattern);
-
-  if (matchDetector && matchSha) {
-    const detector = matchDetector[1].trim();
-    const secretSha = matchSha[1].trim();
-    return { detector, secretSha };
-  } else {
-    throw new Error("No match found");
-  }
 }
 
 export function generateSecretName(

--- a/src/lib/ggshield-results-parser.ts
+++ b/src/lib/ggshield-results-parser.ts
@@ -25,6 +25,12 @@ const validityDisplayName: Record<Validity, string> = {
   valid: "Valid",
 };
 
+export interface GitGuardianDiagnostic extends Diagnostic {
+  detector: string;
+  secretSha: string;
+  details: string;
+}
+
 /**
  * Given a list of occurrences, this function searches for the matches of type "connection_uri"
  * and returns it if found. If no "connection_uri" match is found, the original list is returned.
@@ -40,6 +46,37 @@ function filterUriOccurrences(occurrences: Occurrence[]): Occurrence[] {
   return uriOccurrence ? [uriOccurrence] : occurrences;
 }
 
+function buildVaultInfo(incident: Incident): string {
+  if (!incident.secret_vaulted) {
+    return "Secret found in vault: NO";
+  }
+  if (incident.vault_path_count !== null) {
+    return `Secret found in vault: YES (${
+      incident.vault_path_count
+    } ${pluralize(incident.vault_path_count, "location")})
+├─ Vault Type: ${incident.vault_type}
+├─ Vault Name: ${incident.vault_name}
+└─ Secret Path: ${incident.vault_path}`;
+  }
+  return "Secret found in vault: YES";
+}
+
+function buildDetails(
+  incident: Incident,
+  occurrence: Occurrence,
+  vaultInfo: string,
+): string {
+  return `ggshield: ${occurrence.type}
+
+Secret detected: ${incident.type}
+Validity: ${validityDisplayName[incident.validity]}
+Known by GitGuardian dashboard: ${incident.known_secret ? "YES" : "NO"}
+Total occurrences: ${incident.total_occurrences}
+Incident URL: ${incident.incident_url || "N/A"}
+Secret SHA: ${incident.ignore_sha}
+${vaultInfo}`;
+}
+
 /**
  * Parse ggshield results and return diagnostics of found incidents
  *
@@ -49,8 +86,8 @@ function filterUriOccurrences(occurrences: Occurrence[]): Occurrence[] {
 
 export function parseGGShieldResults(
   results: GGShieldScanResults,
-): Diagnostic[] {
-  let diagnostics: Diagnostic[] = [];
+): GitGuardianDiagnostic[] {
+  let diagnostics: GitGuardianDiagnostic[] = [];
 
   try {
     if (!results.entities_with_incidents) {
@@ -66,38 +103,26 @@ export function parseGGShieldResults(
                 new Position(occurrence.line_end - 1, occurrence.index_end),
               );
 
-              let vaultInfo = "";
+              const vaultInfo = buildVaultInfo(incident);
+              const message = `ggshield: ${occurrence.type} - ${
+                incident.type
+              } (${validityDisplayName[incident.validity]})`;
 
-              if (incident.secret_vaulted) {
-                if (incident.vault_path_count !== null) {
-                  vaultInfo += `Secret found in vault: YES (${
-                    incident.vault_path_count
-                  } ${pluralize(incident.vault_path_count, "location")})
-├─ Vault Type: ${incident.vault_type}
-├─ Vault Name: ${incident.vault_name}
-└─ Secret Path: ${incident.vault_path}`;
-                } else {
-                  vaultInfo += "Secret found in vault: YES";
-                }
-              } else {
-                vaultInfo += "Secret found in vault: NO";
-              }
-
-              let diagnostic = new Diagnostic(
+              const diagnostic = new Diagnostic(
                 range,
-                `ggshield: ${occurrence.type}
-
-Secret detected: ${incident.type}
-Validity: ${validityDisplayName[incident.validity]}
-Known by GitGuardian dashboard: ${incident.known_secret ? "YES" : "NO"}
-Total occurrences: ${incident.total_occurrences}
-Incident URL: ${incident.incident_url || "N/A"}
-Secret SHA: ${incident.ignore_sha}
-${vaultInfo}`,
+                message,
                 DiagnosticSeverity.Warning,
+              ) as GitGuardianDiagnostic;
+
+              diagnostic.source = "gitguardian";
+              diagnostic.detector = incident.type;
+              diagnostic.secretSha = incident.ignore_sha;
+              diagnostic.details = buildDetails(
+                incident,
+                occurrence,
+                vaultInfo,
               );
 
-              diagnostic.source = "\ngitguardian";
               diagnostics.push(diagnostic);
             },
           );

--- a/src/test/suite/results-parser.test.ts
+++ b/src/test/suite/results-parser.test.ts
@@ -10,15 +10,29 @@ import {
 } from "../constants";
 
 suite("parseGGShieldResults", () => {
-  test("Should parse ggshield scan output", () => {
+  test("Should parse ggshield scan output into a single-line message", () => {
     const diagnostics = parseGGShieldResults(
       JSON.parse(scanResultsWithIncident),
     );
     assert.strictEqual(diagnostics.length, 1);
     const diagnostic = diagnostics[0];
-    assert.ok(diagnostic.message.includes("apikey"));
-    assert.ok(diagnostic.message.includes("Generic High Entropy Secret"));
-    assert.ok(diagnostic.message.includes("Secret found in vault: NO"));
+    assert.strictEqual(
+      diagnostic.message,
+      "ggshield: apikey - Generic High Entropy Secret (No Checker)",
+    );
+    assert.ok(!diagnostic.message.includes("\n"));
+    assert.strictEqual(diagnostic.source, "gitguardian");
+    assert.strictEqual(diagnostic.detector, "Generic High Entropy Secret");
+    assert.strictEqual(
+      diagnostic.secretSha,
+      "38353eb1a2aac5b24f39ed67912234d4b4a2e23976d504a88b28137ed2b9185e",
+    );
+    assert.ok(
+      diagnostic.details.includes(
+        "Secret detected: Generic High Entropy Secret",
+      ),
+    );
+    assert.ok(diagnostic.details.includes("Secret found in vault: NO"));
     assert.strictEqual(diagnostic.range.start.line, 3);
     assert.strictEqual(diagnostic.range.start.character, 11);
     assert.strictEqual(diagnostic.range.end.line, 3);
@@ -26,18 +40,19 @@ suite("parseGGShieldResults", () => {
     assert.strictEqual(diagnostic.severity, DiagnosticSeverity.Warning);
   });
 
-  test("Should parse vault information", () => {
+  test("Should expose vault information in details", () => {
     const diagnostics = parseGGShieldResults(JSON.parse(scanResultsVaulted));
     const diagnostic = diagnostics[0];
-    assert.ok(diagnostic.message.includes("Secret found in vault: YES"));
+    assert.ok(!diagnostic.message.includes("\n"));
+    assert.ok(diagnostic.details.includes("Secret found in vault: YES"));
     assert.ok(
-      diagnostic.message.includes("├─ Vault Type: AWS Secrets Manager"),
+      diagnostic.details.includes("├─ Vault Type: AWS Secrets Manager"),
     );
     assert.ok(
-      diagnostic.message.includes("├─ Vault Name: 463175827647/us-west-2"),
+      diagnostic.details.includes("├─ Vault Name: 463175827647/us-west-2"),
     );
     assert.ok(
-      diagnostic.message.includes(
+      diagnostic.details.includes(
         "└─ Secret Path: arn:aws:secretsmanager:us-west-2:463175827647:secret:xav-test-svef2q:pwd",
       ),
     );


### PR DESCRIPTION
## Context

Currently, we display a detailed, multi-line message for each secret we find in VSCode's Problems View. The Problems View lists all issues raised from installed extensions by file. By convention, the individual problem message should spawn only one line.

## What has been done

This PR shortens the result of a `ggshield` scan to one line per finding. The full finding data remains visible through the hover window.

## Validation

- run the extension
- open a repository that contains an inline secret detected by `ggshield`
- open the Problems View
- ensure that the secret issue is summarized in a single line

## PR check list

- [x] As much as possible, the changes include tests
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
