### PR TITLE
feat: add findings panel in gitguardian sidebar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         exclude: ^(ggshield-internal)
 
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.43.0
+    rev: v1.50.3
     hooks:
       - id: ggshield
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - Quota view now shows the connected GitGuardian instance and exposes a title-bar action to open the instance URL setting. The view refreshes automatically when `gitguardian.apiUrl` changes.
+- New "Findings" tree view in the GitGuardian sidebar listing detected secrets grouped by file.
+
+### Fixed
+
+- Diagnostics for a file are now cleared when a re-scan finds no secrets, so previously reported findings no longer linger after they have been resolved.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,15 @@
         }
       },
       {
+        "command": "gitguardian.refreshFindings",
+        "title": "Refresh Findings",
+        "category": "GitGuardian",
+        "icon": {
+          "light": "images/refresh-light.svg",
+          "dark": "images/refresh-dark.svg"
+        }
+      },
+      {
         "command": "gitguardian.openInstanceSettings",
         "title": "Configure instance URL",
         "category": "GitGuardian",
@@ -125,6 +134,12 @@
     },
     "views": {
       "gitguardian": [
+        {
+          "type": "tree",
+          "id": "gitguardianFindingsView",
+          "name": "Findings",
+          "when": "isAuthenticated == true"
+        },
         {
           "type": "webview",
           "id": "gitguardianView",
@@ -150,6 +165,10 @@
       {
         "view": "gitguardianView",
         "contents": "To get started with GitGuardian, please authenticate.\n[Authenticate](command:gitguardian.authenticate)"
+      },
+      {
+        "view": "gitguardianFindingsView",
+        "contents": "No secrets detected yet.\nSave a file to scan it for secrets."
       }
     ],
     "menus": {
@@ -163,6 +182,11 @@
           "command": "gitguardian.openInstanceSettings",
           "group": "navigation@2",
           "when": "view == gitguardianQuotaView"
+        },
+        {
+          "command": "gitguardian.refreshFindings",
+          "group": "navigation@1",
+          "when": "view == gitguardianFindingsView"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import {
 } from "./gitguardian-interface/gitguardian-hover-provider";
 import { GitGuardianQuotaWebviewProvider } from "./ggshield-webview/gitguardian-quota-webview";
 import { GitGuardianRemediationMessageWebviewProvider } from "./ggshield-webview/gitguardian-remediation-message-view";
+import { GitGuardianFindingsProvider } from "./gitguardian-interface/gitguardian-findings-tree";
 import {
   AuthenticationStatus,
   loginGGShield,
@@ -111,6 +112,13 @@ export async function activate(context: ExtensionContext) {
     ggshieldQuotaViewProvider,
   );
 
+  const findingsProvider = new GitGuardianFindingsProvider();
+  const findingsTreeView = window.createTreeView("gitguardianFindingsView", {
+    treeDataProvider: findingsProvider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(findingsProvider, findingsTreeView);
+
   createStatusBarItem(context);
 
   //generic commands to open correct view on status bar click
@@ -124,6 +132,9 @@ export async function activate(context: ExtensionContext) {
         "workbench.action.openSettings",
         "gitguardian.apiUrl",
       ),
+    ),
+    commands.registerCommand("gitguardian.refreshFindings", () =>
+      findingsProvider.refresh(),
     ),
   );
 
@@ -169,6 +180,17 @@ export async function activate(context: ExtensionContext) {
   // Start scanning documents on activation events
   // (i.e. when a new document is opened or when the document is saved)
   createDiagnosticCollection(context);
+
+  // Clean up diagnostics when a tracked file is renamed. Deletes are handled by
+  // per-URI watchers registered in ggshield-api when diagnostics are produced.
+  context.subscriptions.push(
+    workspace.onDidRenameFiles((event) => {
+      for (const { oldUri } of event.files) {
+        cleanUpFileDiagnostics(oldUri);
+      }
+    }),
+  );
+
   context.subscriptions.push(
     { dispose: cancelInFlightScans },
     workspace.onDidSaveTextDocument((textDocument) => {
@@ -190,9 +212,6 @@ export async function activate(context: ExtensionContext) {
         });
       }
     }),
-    workspace.onDidCloseTextDocument((textDocument) =>
-      cleanUpFileDiagnostics(textDocument.uri),
-    ),
     commands.registerCommand("gitguardian.quota", async () => {
       try {
         await showAPIQuota(ggshieldResolver.configuration);

--- a/src/gitguardian-interface/gitguardian-findings-tree.ts
+++ b/src/gitguardian-interface/gitguardian-findings-tree.ts
@@ -1,0 +1,172 @@
+import * as vscode from "vscode";
+import { GitGuardianDiagnostic } from "../lib/ggshield-results-parser";
+
+type FindingsNode = FileNode | SecretNode | MatchNode;
+
+class FileNode extends vscode.TreeItem {
+  constructor(
+    public readonly uri: vscode.Uri,
+    public readonly diagnostics: GitGuardianDiagnostic[],
+  ) {
+    super(
+      vscode.workspace.asRelativePath(uri),
+      vscode.TreeItemCollapsibleState.Expanded,
+    );
+    this.resourceUri = uri;
+    const secretCount = new Set(diagnostics.map((d) => d.secretSha)).size;
+    this.description = `${secretCount} secret${secretCount === 1 ? "" : "s"}`;
+    this.contextValue = "gitguardianFindingsFile";
+  }
+}
+
+class SecretNode extends vscode.TreeItem {
+  constructor(
+    public readonly uri: vscode.Uri,
+    public readonly diagnostics: GitGuardianDiagnostic[],
+  ) {
+    const first = diagnostics[0];
+    const isSingle = diagnostics.length === 1;
+    super(
+      first.detector || "Secret",
+      isSingle
+        ? vscode.TreeItemCollapsibleState.None
+        : vscode.TreeItemCollapsibleState.Collapsed,
+    );
+    this.iconPath = new vscode.ThemeIcon(
+      "warning",
+      new vscode.ThemeColor("editorWarning.foreground"),
+    );
+    this.contextValue = "gitguardianFindingsItem";
+    if (isSingle) {
+      this.description = `Line ${first.range.start.line + 1}`;
+      const tooltip = new vscode.MarkdownString();
+      tooltip.appendCodeblock(first.message, "text");
+      this.tooltip = tooltip;
+      this.command = {
+        command: "vscode.open",
+        title: "Open Finding",
+        arguments: [uri, { selection: first.range }],
+      };
+    } else {
+      this.description = `${diagnostics.length} matches`;
+    }
+  }
+}
+
+class MatchNode extends vscode.TreeItem {
+  constructor(
+    public readonly uri: vscode.Uri,
+    public readonly diagnostic: GitGuardianDiagnostic,
+  ) {
+    super(
+      diagnostic.matchType || "match",
+      vscode.TreeItemCollapsibleState.None,
+    );
+    this.description = `Line ${diagnostic.range.start.line + 1}`;
+    const tooltip = new vscode.MarkdownString();
+    tooltip.appendCodeblock(diagnostic.message, "text");
+    this.tooltip = tooltip;
+    this.command = {
+      command: "vscode.open",
+      title: "Open Finding",
+      arguments: [uri, { selection: diagnostic.range }],
+    };
+    this.contextValue = "gitguardianFindingsItem";
+  }
+}
+
+function groupBySecret(
+  diagnostics: GitGuardianDiagnostic[],
+): GitGuardianDiagnostic[][] {
+  const groups = new Map<string, GitGuardianDiagnostic[]>();
+  for (const d of diagnostics) {
+    const key = d.secretSha;
+    const group = groups.get(key);
+    if (group) {
+      group.push(d);
+    } else {
+      groups.set(key, [d]);
+    }
+  }
+  return Array.from(groups.values()).map((group) =>
+    group.slice().sort((a, b) => a.range.start.line - b.range.start.line),
+  );
+}
+
+export class GitGuardianFindingsProvider
+  implements vscode.TreeDataProvider<FindingsNode>, vscode.Disposable
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+    FindingsNode | undefined | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private readonly diagnosticsListener: vscode.Disposable;
+  // Tracks URIs that currently have GitGuardian diagnostics so we can detect
+  // when GG diagnostics are removed (the post-change `getDiagnostics(uri)` call
+  // alone can't tell us a GG diagnostic just disappeared from this URI).
+  private readonly ggUris = new Set<string>();
+
+  constructor() {
+    this.diagnosticsListener = vscode.languages.onDidChangeDiagnostics((e) => {
+      let relevant = false;
+      for (const uri of e.uris) {
+        const key = uri.toString();
+        const hasGG = vscode.languages
+          .getDiagnostics(uri)
+          .some((d) => d.source?.trim() === "gitguardian");
+        const hadGG = this.ggUris.has(key);
+        if (hasGG) {
+          this.ggUris.add(key);
+        } else if (hadGG) {
+          this.ggUris.delete(key);
+        }
+        if (hasGG || hadGG) {
+          relevant = true;
+        }
+      }
+      if (relevant) {
+        this._onDidChangeTreeData.fire();
+      }
+    });
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: FindingsNode): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: FindingsNode): FindingsNode[] {
+    if (!element) {
+      return vscode.languages
+        .getDiagnostics()
+        .map(([uri, diagnostics]) => {
+          const ggDiagnostics = diagnostics.filter(
+            (d) => d.source?.trim() === "gitguardian",
+          ) as GitGuardianDiagnostic[];
+          return ggDiagnostics.length > 0
+            ? new FileNode(uri, ggDiagnostics)
+            : undefined;
+        })
+        .filter((node): node is FileNode => node !== undefined)
+        .sort((a, b) => (a.label as string).localeCompare(b.label as string));
+    }
+    if (element instanceof FileNode) {
+      return groupBySecret(element.diagnostics)
+        .sort((a, b) => a[0].range.start.line - b[0].range.start.line)
+        .map((group) => new SecretNode(element.uri, group));
+    }
+    if (element instanceof SecretNode && element.diagnostics.length > 1) {
+      return element.diagnostics.map((d) => new MatchNode(element.uri, d));
+    }
+    return [];
+  }
+
+  dispose(): void {
+    this.diagnosticsListener.dispose();
+    this._onDidChangeTreeData.dispose();
+  }
+}

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import * as path from "path";
 import {
   window,
+  Disposable,
   DiagnosticCollection,
   ExtensionContext,
   languages,
+  RelativePattern,
   Uri,
   Diagnostic,
+  workspace,
 } from "vscode";
 import { GGShieldConfiguration } from "./ggshield-configuration";
 import { isFileGitignored } from "../utils";
@@ -20,6 +24,60 @@ import { parseGGShieldResults } from "./ggshield-results-parser";
  * Extension diagnostic collection
  */
 export let diagnosticCollection: DiagnosticCollection;
+
+// Per-URI delete watchers, registered only for files we currently track
+// diagnostics for.
+const fileWatchers = new Map<string, Disposable>();
+
+function watchUriForRemoval(fileUri: Uri): void {
+  const key = fileUri.toString();
+  if (fileWatchers.has(key)) {
+    return;
+  }
+  const folder = workspace.getWorkspaceFolder(fileUri);
+  if (!folder) {
+    return;
+  }
+  const relativePath = path.relative(folder.uri.fsPath, fileUri.fsPath);
+  if (!relativePath || relativePath.startsWith("..")) {
+    return;
+  }
+  // RelativePattern expects a glob, so use forward slashes on Windows too.
+  const globPath = relativePath.split(path.sep).join("/");
+  const watcher = workspace.createFileSystemWatcher(
+    new RelativePattern(folder, globPath),
+    true, // ignoreCreateEvents
+    true, // ignoreChangeEvents
+    false, // listen for delete
+  );
+  const subscription = watcher.onDidDelete(() => {
+    cleanUpFileDiagnostics(fileUri);
+  });
+  fileWatchers.set(key, {
+    dispose: () => {
+      subscription.dispose();
+      watcher.dispose();
+    },
+  });
+}
+
+function unwatchUri(fileUri: Uri): void {
+  const key = fileUri.toString();
+  const watcher = fileWatchers.get(key);
+  if (watcher) {
+    watcher.dispose();
+    fileWatchers.delete(key);
+  }
+}
+
+function setDiagnostics(fileUri: Uri, diagnostics: Diagnostic[]): void {
+  diagnosticCollection.set(fileUri, diagnostics);
+  if (diagnostics.length > 0) {
+    watchUriForRemoval(fileUri);
+  } else {
+    unwatchUri(fileUri);
+  }
+}
 
 // Tracks the in-flight scan per URI so a later save can abort an earlier one
 // and we can drop stale results that return after being superseded.
@@ -131,6 +189,7 @@ export function createDiagnosticCollection(context: ExtensionContext): void {
  */
 export function cleanUpFileDiagnostics(fileUri: Uri): void {
   diagnosticCollection.delete(fileUri);
+  unwatchUri(fileUri);
 }
 
 /**
@@ -151,6 +210,7 @@ export async function scanFile(
 ): Promise<void> {
   if (isFileGitignored(filePath)) {
     updateStatusBarItem(StatusBarStatus.ignoredFile);
+    cleanUpFileDiagnostics(fileUri);
     return;
   }
 
@@ -198,16 +258,18 @@ export async function scanFile(
       )
     ) {
       updateStatusBarItem(StatusBarStatus.ignoredFile);
+      cleanUpFileDiagnostics(fileUri);
       return;
     }
     return undefined;
   } else if (proc.status === 0) {
     updateStatusBarItem(StatusBarStatus.noSecretFound);
+    cleanUpFileDiagnostics(fileUri);
     return;
   } else {
     updateStatusBarItem(StatusBarStatus.secretFound);
   }
   const results = JSON.parse(proc.stdout);
   let incidentsDiagnostics: Diagnostic[] = parseGGShieldResults(results);
-  diagnosticCollection.set(fileUri, incidentsDiagnostics);
+  setDiagnostics(fileUri, incidentsDiagnostics);
 }

--- a/src/lib/ggshield-results-parser.ts
+++ b/src/lib/ggshield-results-parser.ts
@@ -28,6 +28,7 @@ const validityDisplayName: Record<Validity, string> = {
 export interface GitGuardianDiagnostic extends Diagnostic {
   detector: string;
   secretSha: string;
+  matchType: string;
   details: string;
 }
 
@@ -117,6 +118,7 @@ export function parseGGShieldResults(
               diagnostic.source = "gitguardian";
               diagnostic.detector = incident.type;
               diagnostic.secretSha = incident.ignore_sha;
+              diagnostic.matchType = occurrence.type;
               diagnostic.details = buildDetails(
                 incident,
                 occurrence,


### PR DESCRIPTION
## Context

Findings from `ggshield` scans are currently only surfaced in the Problems panel and inline as squiggles. There is no consolidated view of secrets detected across the open workspace.

## What has been done

- add a "Findings" tree view in the GitGuardian sidebar, grouping detected secrets by file. Clicking a finding jumps to its location
- add a `gitguardian.refreshFindings` title-bar action to manually rebuild the list
- clear the diagnostic collection for a file when a re-scan finishes with no findings, so resolved secrets disappear from the editor and the new tree view
- export extractInfosFromMessage from the hover provider so the tree can reuse it to label findings by detector


## Validation

- run the extension
- open a repository that contains an inline secret detected by ggshield
- ensure the new "Findings" view in the GitGuardian sidebar lists the file with a secret count, and that expanding it shows one entry per finding labelled with the detector
- click an entry and ensure the editor jumps to the matching range
- remove the secret from the file and save
- ensure the file disappears from the "Findings" view and the inline squiggle is cleared

## PR check list

- [x] As much as possible, the changes include tests
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
