### PR TITLE
ci: release and publish through ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - "main"
-    tags:
-      - "v*"
+  workflow_call:
 
 permissions:
   contents: read
@@ -39,10 +38,11 @@ jobs:
         run: |
           npx vsce package --target ${{ matrix.target }} \
             --baseContentUrl https://github.com/GitGuardian/gitguardian-vscode/ \
-            --allow-missing-repository
+            --allow-missing-repository \
+            -o gitguardian-${{ matrix.target }}.vsix
 
       - name: Upload extension package
         uses: actions/upload-artifact@v7
         with:
           name: gitguardian-${{ matrix.target }}.vsix
-          path: gitguardian-*.vsix
+          path: gitguardian-${{ matrix.target }}.vsix

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - "main"
-    tags:
-      - "v*"
+  workflow_call:
 
 permissions:
   contents: read
@@ -33,7 +32,7 @@ jobs:
           node-version: 22
 
       - name: Setup VSCE
-        run: sudo yarn global add vsce@latest
+        run: sudo yarn global add @vscode/vsce@3.9.1
 
       - name: Install dependencies
         run: yarn install
@@ -42,7 +41,8 @@ jobs:
         run: |
           vsce package --target ${{ matrix.target }} \
             --baseContentUrl https://github.com/GitGuardian/gitguardian-vscode/ \
-            --allow-missing-repository
+            --allow-missing-repository \
+            -o gitguardian-${{ matrix.target }}.vsix
         env:
           GGSHIELD_TARGET: ${{ matrix.target }}
 
@@ -50,4 +50,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gitguardian-${{ matrix.target }}.vsix
-          path: gitguardian-*.vsix
+          path: gitguardian-${{ matrix.target }}.vsix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download all VSIXes
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: gitguardian-*.vsix
+          merge-multiple: true
+
+      - name: Publish to Visual Studio Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PUBLISH_KEY }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          vsixes=(dist/gitguardian-*.vsix)
+          if [ ${#vsixes[@]} -eq 0 ]; then
+            echo "No VSIXes found in dist/" >&2
+            exit 1
+          fi
+          for vsix in "${vsixes[@]}"; do
+            npx --yes @vscode/vsce@3.9.1 publish --skip-duplicate --packagePath "$vsix"
+          done
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PUBLISH_KEY }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          vsixes=(dist/gitguardian-*.vsix)
+          if [ ${#vsixes[@]} -eq 0 ]; then
+            echo "No VSIXes found in dist/" >&2
+            exit 1
+          fi
+          for vsix in "${vsixes[@]}"; do
+            target=$(basename "$vsix" .vsix)
+            target=${target#gitguardian-}
+            npx --yes ovsx@0.10.12 publish --skip-duplicate -i "$vsix" -t "$target"
+          done
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all VSIXes
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: gitguardian-*.vsix
+          merge-multiple: true
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          vsixes=(dist/*.vsix)
+          if [ ${#vsixes[@]} -eq 0 ]; then
+            echo "No VSIXes found in dist/" >&2
+            exit 1
+          fi
+          gh release create "${GITHUB_REF_NAME}" "${vsixes[@]}" \
+            --draft \
+            --generate-notes \
+            --title "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,76 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-x64
+          - target: darwin-arm64
+          - target: linux-x64
+          - target: win32-x64
+          - target: win32-arm64
+    steps:
+      - name: Setup Node.js and tools
+        uses: jdx/mise-action@v4
+
+      - name: Download VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: gitguardian-${{ matrix.target }}.vsix
+
+      - name: Publish to Visual Studio Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PUBLISH_KEY }}
+        run: npx --yes @vscode/vsce@3.9.1 publish --skip-duplicate --packagePath gitguardian-${{ matrix.target }}.vsix
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PUBLISH_KEY }}
+        run: npx --yes ovsx@0.10.12 publish --skip-duplicate -i gitguardian-${{ matrix.target }}.vsix -t ${{ matrix.target }}
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download all VSIXes
+        uses: actions/download-artifact@v8
+        with:
+          pattern: gitguardian-*.vsix
+          merge-multiple: true
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          vsixes=(*.vsix)
+          if [ ${#vsixes[@]} -eq 0 ]; then
+            echo "No VSIXes found" >&2
+            exit 1
+          fi
+          gh release create "${GITHUB_REF_NAME}" "${vsixes[@]}" \
+            --draft \
+            --generate-notes \
+            --title "${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Context

Currently our release process involves a lot of manual CLI acrobatics.

## What has been done

Add a release action that creates a draft release and publishes extensions on Visual Studio Marketplace and Open VSX.
I also restricted pushing tags to `ggshield-admins` only

## PR check list

- [ ] As much as possible, the changes include tests
- [ ] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
