### PR TITLE
fix: add missing eslint-config-prettier dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@vscode/vsce": "^3",
         "esbuild": "^0.25.12",
         "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "mocha": "^11",
         "sinon": "^21.0.3",
@@ -3405,15 +3406,16 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
-      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "@vscode/vsce": "^3",
     "esbuild": "^0.25.12",
     "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "mocha": "^11",
     "sinon": "^21.0.3",


### PR DESCRIPTION
## Summary
- Adds `eslint-config-prettier` as an explicit `devDependency`
- This peer dependency of `eslint-plugin-prettier` was previously pulled in transitively but not declared, causing CI to fail with `Cannot find module 'eslint-config-prettier'` on clean installs

## Test plan
- [ ] CI lint step passes