### PR TITLE
6d7a/fix quota display not showing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: eslint
         name: eslint
         verbose: false
-        language: node
+        language: system
         types: [file]
         entry: npm run lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GitGuardian Secret Security Changelog
 
+## [0.24.0]
+
+### Fixed
+
+- The Quota view is now hidden for members whose access level does not allow reading the workspace quota.
+
 ## [0.23.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,9 +2102,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
           "id": "gitguardianQuotaView",
           "name": "Quota",
           "collapsed": true,
-          "when": "isAuthenticated == true"
+          "when": "isAuthenticated == true && !isQuotaForbidden"
         }
       ]
     },

--- a/src/ggshield-webview/gitguardian-quota-webview.ts
+++ b/src/ggshield-webview/gitguardian-quota-webview.ts
@@ -9,10 +9,12 @@ export class GitGuardianQuotaWebviewProvider
 {
   public static readonly viewType = "gitguardian.gitguardianQuotaView";
   private _view?: vscode.WebviewView;
-  private quota: number = 0;
+  private quota: number | undefined;
   private isLoading: boolean = false;
   private isAuthenticated: boolean = false;
+  private isQuotaForbidden: boolean = false;
   private instance: string = "";
+  private refreshGeneration: number = 0;
 
   constructor(
     private ggshieldConfiguration: GGShieldConfiguration,
@@ -30,6 +32,10 @@ export class GitGuardianQuotaWebviewProvider
       console.error("GitGuardian quota refresh failed:", err);
     });
 
+    webviewView.onDidDispose(() => {
+      this._view = undefined;
+    });
+
     webviewView.onDidChangeVisibility(() => {
       if (webviewView.visible) {
         // Refresh the quota when the view becomes visible (e.g., after being collapsed and reopened)
@@ -44,16 +50,33 @@ export class GitGuardianQuotaWebviewProvider
     this.ggshieldConfiguration = configuration;
   }
 
-  private async updateQuota(): Promise<void> {
+  private async updateQuota(generation: number): Promise<void> {
     const authStatus: AuthenticationStatus | undefined =
       this.context.workspaceState.get("authenticationStatus");
     this.isAuthenticated = authStatus?.success ?? false;
     this.instance = authStatus?.instance ?? "";
-    if (authStatus?.success) {
-      this.quota = await getAPIquota(this.ggshieldConfiguration);
-    } else {
-      this.quota = 0;
+    if (!authStatus?.success) {
+      this.quota = undefined;
+      this.setQuotaForbidden(false);
+      return;
     }
+
+    const result = await getAPIquota(this.ggshieldConfiguration);
+    if (generation !== this.refreshGeneration) {
+      return;
+    }
+
+    this.quota = result.status === "available" ? result.remaining : undefined;
+    this.setQuotaForbidden(result.status === "forbidden");
+  }
+
+  private setQuotaForbidden(isForbidden: boolean): void {
+    this.isQuotaForbidden = isForbidden;
+    void vscode.commands.executeCommand(
+      "setContext",
+      "isQuotaForbidden",
+      isForbidden,
+    );
   }
 
   private renderConnectedLine(): string {
@@ -68,12 +91,17 @@ export class GitGuardianQuotaWebviewProvider
       return;
     }
 
+    if (this.isQuotaForbidden) {
+      this._view.webview.html = "";
+      return;
+    }
+
     const connectedLine = this.renderConnectedLine();
 
     let body: string;
     if (this.isLoading) {
       body = `${connectedLine}<p>Loading...</p>`;
-    } else if (this.quota !== 0 && this.isAuthenticated) {
+    } else if (this.quota !== undefined && this.isAuthenticated) {
       body = `${connectedLine}<p>Your current quota: ${this.quota}</p>`;
     } else {
       body = `${connectedLine}<p>Please authenticate to see your quota.</p>`;
@@ -89,20 +117,21 @@ export class GitGuardianQuotaWebviewProvider
   }
 
   public async refresh(): Promise<void> {
+    const generation = ++this.refreshGeneration;
     this.isLoading = true;
     this.updateWebViewContent();
 
-    await this.updateQuota();
-
-    this.isLoading = false;
-    this.updateWebViewContent();
+    try {
+      await this.updateQuota(generation);
+    } finally {
+      if (generation === this.refreshGeneration) {
+        this.isLoading = false;
+        this.updateWebViewContent();
+      }
+    }
   }
 
   dispose(): void {
-    if (this._view) {
-      this._view.webview.onDidReceiveMessage(() => {});
-      this._view.webview.html = "";
-      this._view = undefined;
-    }
+    this._view = undefined;
   }
 }

--- a/src/lib/ggshield-api.ts
+++ b/src/lib/ggshield-api.ts
@@ -103,25 +103,63 @@ export async function showAPIQuota(
     return;
   }
 
-  const proc = await runGGShieldCommand(configuration, ["quota"]);
+  const result = await getAPIquota(configuration);
 
-  if (proc.stderr.length > 0) {
-    window.showErrorMessage(`ggshield: ${proc.stderr}`);
-  }
-  if (proc.stdout.length > 0) {
-    window.showInformationMessage(`ggshield: ${proc.stdout}`);
+  switch (result.status) {
+    case "available":
+      window.showInformationMessage(
+        `ggshield: Your current quota: ${result.remaining}`,
+      );
+      break;
+    case "forbidden":
+      window.showWarningMessage(
+        "ggshield: Reading the API quota requires the Manager access level.",
+      );
+      break;
+    case "unavailable":
+      window.showErrorMessage(
+        result.detail
+          ? `ggshield: could not retrieve the API quota: ${result.detail}`
+          : "ggshield: could not retrieve the API quota.",
+      );
+      break;
   }
 }
 
+export type QuotaResult =
+  | { status: "available"; remaining: number }
+  | { status: "forbidden" }
+  | { status: "unavailable"; detail: string };
+
+// GET /v1/quotas is Manager-only and ggshield discards the HTTP status, so the
+// 403 a plain member gets is only recognizable by its message.
+const MANAGER_ONLY_QUOTA_ERROR = "must have Manager access level";
+
 export async function getAPIquota(
   configuration: GGShieldConfiguration,
-): Promise<number> {
-  try {
-    const proc = await runGGShieldCommand(configuration, ["quota", "--json"]);
-    return JSON.parse(proc.stdout).remaining;
-  } catch {
-    return 0;
+): Promise<QuotaResult> {
+  const proc = await runGGShieldCommand(configuration, ["quota", "--json"]);
+  const unavailable: QuotaResult = {
+    status: "unavailable",
+    detail: proc.stderr.trim(),
+  };
+
+  if (proc.status !== 0) {
+    return proc.stderr.includes(MANAGER_ONLY_QUOTA_ERROR)
+      ? { status: "forbidden" }
+      : unavailable;
   }
+
+  let remaining: unknown;
+  try {
+    remaining = JSON.parse(proc.stdout).remaining;
+  } catch {
+    return unavailable;
+  }
+
+  return typeof remaining === "number"
+    ? { status: "available", remaining }
+    : unavailable;
 }
 
 /**

--- a/src/lib/run-ggshield.ts
+++ b/src/lib/run-ggshield.ts
@@ -43,35 +43,35 @@ export function runGGShieldCommand(
     });
   }
 
-  let finalArgs = args.slice();
-  if (configuration.insecure) {
-    finalArgs = ["--insecure"].concat(finalArgs);
-  }
-  if (configuration.apiUrl && !finalArgs.includes("--version")) {
-    finalArgs.push("--instance", configuration.apiUrl);
-  }
-
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    GG_USER_AGENT: "gitguardian-vscode",
-  };
-
-  // If the command is executed in a workspace, execute ggshield from the root
-  // folder so .gitguardian.yaml is used.
-  const cwd = workspace.workspaceFolders?.length
-    ? workspace.workspaceFolders[0].uri.fsPath
-    : os.tmpdir();
-
-  const options: SpawnOptionsWithoutStdio = {
-    cwd,
-    env,
-    windowsHide: true,
-    signal,
-  };
-
   return new Promise<GGShieldCommandResult>((resolve) => {
     let proc;
     try {
+      let finalArgs = args.slice();
+      if (configuration.insecure) {
+        finalArgs = ["--insecure"].concat(finalArgs);
+      }
+      if (configuration.apiUrl && !finalArgs.includes("--version")) {
+        finalArgs.push("--instance", configuration.apiUrl);
+      }
+
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        GG_USER_AGENT: "gitguardian-vscode",
+      };
+
+      // If the command is executed in a workspace, execute ggshield from the root
+      // folder so .gitguardian.yaml is used.
+      const cwd = workspace.workspaceFolders?.length
+        ? workspace.workspaceFolders[0].uri.fsPath
+        : os.tmpdir();
+
+      const options: SpawnOptionsWithoutStdio = {
+        cwd,
+        env,
+        windowsHide: true,
+        signal,
+      };
+
       proc = childProcess.spawn(configuration.ggshieldPath, finalArgs, options);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/src/test/suite/ggshield-webview/gitguardian-quota-webview.test.ts
+++ b/src/test/suite/ggshield-webview/gitguardian-quota-webview.test.ts
@@ -1,7 +1,13 @@
 import assert from "assert";
+import * as sinon from "sinon";
 import { GitGuardianQuotaWebviewProvider } from "../../../ggshield-webview/gitguardian-quota-webview";
 import { GGShieldConfiguration } from "../../../lib/ggshield-configuration";
-import { ExtensionContext, Memento, Uri, WebviewView } from "vscode";
+import {
+  AuthenticationStatus,
+  ConfigSource,
+} from "../../../lib/authentication";
+import * as runGGShield from "../../../lib/run-ggshield";
+import { commands, ExtensionContext, Memento, Uri, WebviewView } from "vscode";
 
 suite("GitGuardianQuotaWebviewProvider", () => {
   let provider: GitGuardianQuotaWebviewProvider;
@@ -42,6 +48,10 @@ suite("GitGuardianQuotaWebviewProvider", () => {
       visible: false,
     };
     provider["_view"] = mockWebviewView as WebviewView;
+  });
+
+  teardown(() => {
+    sinon.restore();
   });
 
   test("should update the webview content when loading", () => {
@@ -109,6 +119,144 @@ suite("GitGuardianQuotaWebviewProvider", () => {
     const html = provider["_view"]?.webview.html ?? "";
 
     assert.ok(html.includes("No instance configured"));
+  });
+
+  suite("when authenticated", () => {
+    let executeCommandMock: sinon.SinonStub;
+    let runGGShieldCommandMock: sinon.SinonStub;
+
+    setup(() => {
+      const authStatus: AuthenticationStatus = {
+        success: true,
+        instance: "https://dashboard.gitguardian.com",
+        keySource: ConfigSource.keyring,
+      };
+      mockWorkspaceState.get = (_key: string) => authStatus;
+      executeCommandMock = sinon.stub(commands, "executeCommand");
+      runGGShieldCommandMock = sinon.stub(runGGShield, "runGGShieldCommand");
+    });
+
+    const setContextCalls = (mock: sinon.SinonStub): unknown[][] =>
+      mock
+        .getCalls()
+        .filter((call) => call.args[0] === "setContext")
+        .map((call) => call.args);
+
+    test("renders nothing and flags the quota as forbidden when the API refuses it", async () => {
+      runGGShieldCommandMock.resolves({
+        status: 128,
+        stdout: "",
+        stderr:
+          "Error: You must have Manager access level to perform this action.",
+      });
+
+      await provider.refresh();
+
+      assert.deepStrictEqual(setContextCalls(executeCommandMock), [
+        ["setContext", "isQuotaForbidden", true],
+      ]);
+      assert.strictEqual(provider["_view"]?.webview.html, "");
+    });
+
+    test("keeps rendering nothing while a forbidden quota is refreshed", async () => {
+      runGGShieldCommandMock.resolves({
+        status: 128,
+        stdout: "",
+        stderr:
+          "Error: You must have Manager access level to perform this action.",
+      });
+
+      await provider.refresh();
+      provider["isLoading"] = true;
+      provider["updateWebViewContent"]();
+
+      assert.strictEqual(provider["_view"]?.webview.html, "");
+    });
+
+    test("clears the forbidden flag once the quota is readable", async () => {
+      runGGShieldCommandMock.resolves({
+        status: 0,
+        stdout: '{"count": 560, "limit": 10000, "remaining": 9440}',
+        stderr: "",
+      });
+
+      await provider.refresh();
+
+      assert.deepStrictEqual(setContextCalls(executeCommandMock), [
+        ["setContext", "isQuotaForbidden", false],
+      ]);
+      assert.ok(
+        provider["_view"]?.webview.html.includes(
+          "<p>Your current quota: 9440</p>",
+        ),
+      );
+    });
+
+    test("clears the forbidden flag when authentication is lost", async () => {
+      runGGShieldCommandMock.resolves({
+        status: 128,
+        stdout: "",
+        stderr:
+          "Error: You must have Manager access level to perform this action.",
+      });
+
+      await provider.refresh();
+      assert.strictEqual(provider["isQuotaForbidden"], true);
+
+      mockWorkspaceState.get = (_key: string) => undefined;
+      await provider.refresh();
+
+      assert.strictEqual(provider["isQuotaForbidden"], false);
+      assert.deepStrictEqual(setContextCalls(executeCommandMock), [
+        ["setContext", "isQuotaForbidden", true],
+        ["setContext", "isQuotaForbidden", false],
+      ]);
+      assert.ok(
+        provider["_view"]?.webview.html.includes(
+          "<p>Please authenticate to see your quota.</p>",
+        ),
+      );
+    });
+
+    test("drops the result of a refresh that was superseded", async () => {
+      const resolvers: Array<
+        (value: { status: number; stdout: string; stderr: string }) => void
+      > = [];
+      runGGShieldCommandMock.callsFake(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(resolve);
+          }),
+      );
+
+      const superseded = provider.refresh();
+      const latest = provider.refresh();
+
+      resolvers[1]({
+        status: 0,
+        stdout: '{"count": 560, "limit": 10000, "remaining": 9440}',
+        stderr: "",
+      });
+      await latest;
+
+      resolvers[0]({
+        status: 128,
+        stdout: "",
+        stderr:
+          "Error: You must have Manager access level to perform this action.",
+      });
+      await superseded;
+
+      assert.strictEqual(provider["isQuotaForbidden"], false);
+      assert.deepStrictEqual(setContextCalls(executeCommandMock), [
+        ["setContext", "isQuotaForbidden", false],
+      ]);
+      assert.ok(
+        provider["_view"]?.webview.html.includes(
+          "<p>Your current quota: 9440</p>",
+        ),
+      );
+    });
   });
 
   test("sanitizes malformed instance URLs", () => {

--- a/src/test/suite/lib/ggshield-api.test.ts
+++ b/src/test/suite/lib/ggshield-api.test.ts
@@ -1,7 +1,11 @@
 import { GGShieldConfiguration } from "../../../lib/ggshield-configuration";
 import * as statusBar from "../../../gitguardian-interface/gitguardian-status-bar";
 import * as sinon from "sinon";
-import { diagnosticCollection, scanFile } from "../../../lib/ggshield-api";
+import {
+  diagnosticCollection,
+  getAPIquota,
+  scanFile,
+} from "../../../lib/ggshield-api";
 import * as runGGShield from "../../../lib/run-ggshield";
 import { Uri, window } from "vscode";
 import {
@@ -159,5 +163,81 @@ suite("scanFile", () => {
       updateStatusBarMock.lastCall.args[0],
       statusBar.StatusBarStatus.ignoredFile,
     );
+  });
+});
+
+suite("getAPIquota", () => {
+  let runGGShieldCommandMock: sinon.SinonStub;
+
+  setup(() => {
+    runGGShieldCommandMock = sinon.stub(runGGShield, "runGGShieldCommand");
+  });
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test("reports the remaining quota", async () => {
+    runGGShieldCommandMock.resolves({
+      status: 0,
+      stdout: '{"count": 560, "limit": 10000, "remaining": 9440}',
+      stderr: "",
+    });
+
+    const result = await getAPIquota({} as GGShieldConfiguration);
+
+    assert.deepStrictEqual(result, { status: "available", remaining: 9440 });
+  });
+
+  test("reports an exhausted quota as available", async () => {
+    runGGShieldCommandMock.resolves({
+      status: 0,
+      stdout: '{"count": 10000, "limit": 10000, "remaining": 0}',
+      stderr: "",
+    });
+
+    const result = await getAPIquota({} as GGShieldConfiguration);
+
+    assert.deepStrictEqual(result, { status: "available", remaining: 0 });
+  });
+
+  test("reports the quota as forbidden when the access level is too low", async () => {
+    runGGShieldCommandMock.resolves({
+      status: 128,
+      stdout: "",
+      stderr:
+        "Error: You must have Manager access level to perform this action.",
+    });
+
+    const result = await getAPIquota({} as GGShieldConfiguration);
+
+    assert.deepStrictEqual(result, { status: "forbidden" });
+  });
+
+  test("reports the quota as unavailable on other failures", async () => {
+    runGGShieldCommandMock.resolves({
+      status: 128,
+      stdout: "",
+      stderr: "Error: Invalid API key.",
+    });
+
+    const result = await getAPIquota({} as GGShieldConfiguration);
+
+    assert.deepStrictEqual(result, {
+      status: "unavailable",
+      detail: "Error: Invalid API key.",
+    });
+  });
+
+  test("reports the quota as unavailable on unparsable output", async () => {
+    runGGShieldCommandMock.resolves({
+      status: 0,
+      stdout: "not json",
+      stderr: "",
+    });
+
+    const result = await getAPIquota({} as GGShieldConfiguration);
+
+    assert.deepStrictEqual(result, { status: "unavailable", detail: "" });
   });
 });

--- a/src/test/suite/lib/run-ggshield.test.ts
+++ b/src/test/suite/lib/run-ggshield.test.ts
@@ -138,6 +138,19 @@ suite("runGGShieldCommand", () => {
     assert.deepStrictEqual(spawnMock.lastCall.args[1], ["--version"]);
   });
 
+  test("returns a failed result instead of throwing when the configuration is unusable", async () => {
+    const result = await runGGShield.runGGShieldCommand(
+      undefined as unknown as GGShieldConfiguration,
+      ["quota", "--json"],
+    );
+
+    assert(!spawnMock.called, "spawn should not be called");
+    assert.strictEqual(result.status, null);
+    assert.strictEqual(result.pid, -1);
+    assert.ok(result.error instanceof Error, "error should be an Error");
+    assert.strictEqual(result.stderr, result.error?.message);
+  });
+
   test("returns a failed result without spawning ggshield in an untrusted workspace", async () => {
     const originalDescriptor = Object.getOwnPropertyDescriptor(
       vscode.workspace,


### PR DESCRIPTION
## Context

Quota information of an API token is not available to all user tiers. 

## What has been done

If an extension user does not have sufficient permissions to retrieve quota information, we just don't display it instead of falsely prompting the user to authenticate.

## Validation

- get an API key for a `member` or `restricted` user of your workspace
- use the API key in the extension
- ensure that no quota is shown and that you are not prompted to authenticate

## PR check list

- [x] As much as possible, the changes include tests
- [x] If the changes affect the end user (new feature, behavior change, bug fix) then the PR has a changelog entry.
